### PR TITLE
001 Manage trip

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,50 +1,39 @@
-# [PROJECT_NAME] Constitution
-<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+# Maletapp Constitution
 
 ## Core Principles
 
-### [PRINCIPLE_1_NAME]
-<!-- Example: I. Library-First -->
-[PRINCIPLE_1_DESCRIPTION]
-<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+### I. Contract-First Delivery
+All externally visible behavior for Items and Trips starts from the domain contract files in `spec/item.yml` and `spec/trip.yml` and their corresponding feature specifications and plans. Implementation must match the contract, and contract changes must be documented in the related specification work in the same session.
 
-### [PRINCIPLE_2_NAME]
-<!-- Example: II. CLI Interface -->
-[PRINCIPLE_2_DESCRIPTION]
-<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+### II. Domain Separation
+Items and Trips are separate sub-APIs. Cross-domain dependencies, shared persistence models, or endpoint behavior that couples the domains are not allowed unless this constitution is amended first.
 
-### [PRINCIPLE_3_NAME]
-<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
-[PRINCIPLE_3_DESCRIPTION]
-<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+### III. Repository and Persistence Discipline
+Application code must depend on repository abstractions rather than direct persistence calls. Persistence implementations must use Entity Framework, with an in-memory provider acceptable for the current stage until a persistent store is intentionally introduced. Domain behavior remains isolated from infrastructure concerns.
 
-### [PRINCIPLE_4_NAME]
-<!-- Example: IV. Integration Testing -->
-[PRINCIPLE_4_DESCRIPTION]
-<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+### IV. Testable by Default
+Every feature must include automated unit tests for domain and application rules and integration tests for API behavior, contract conformance, and persistence wiring. New work is not complete unless both test layers cover the primary flow and relevant failure paths.
 
-### [PRINCIPLE_5_NAME]
-<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
-[PRINCIPLE_5_DESCRIPTION]
-<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+### V. Operational Consistency
+Minimal API endpoints must propagate cancellation, return structured problem details for failures, and avoid leaking unhandled exceptions. Build, test, and formatting checks are required quality gates, and new warnings are treated as failures.
 
-## [SECTION_2_NAME]
-<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+## Delivery Constraints
 
-[SECTION_2_CONTENT]
-<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+- Use C# on .NET 10 with nullable reference types enabled.
+- Public endpoint names must match the relevant OpenAPI `operationId` values exactly.
+- Use typed domain exceptions and structured logging; do not use `Console.WriteLine`.
+- Do not introduce production dependencies in project files without explicit user approval.
+- Authentication flow design is outside the current trip bootstrap scope, but request handling may rely on a current-user accessor abstraction.
 
-## [SECTION_3_NAME]
-<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+## Workflow and Quality Gates
 
-[SECTION_3_CONTENT]
-<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+- One `speckit.tasks` task per session; avoid unrelated scope.
+- Before implementation or commit readiness, `dotnet build --no-incremental`, `dotnet test --no-build`, and `dotnet format --verify-no-changes` must pass with zero new warnings.
+- Planning artifacts must resolve major architectural questions before implementation tasks are generated.
+- Repository changes must preserve clean separation between domain, application, infrastructure, and API concerns where those layers exist.
 
 ## Governance
-<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
 
-[GOVERNANCE_RULES]
-<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+This constitution supersedes conflicting local habits for this repository. Amendments must be reflected in this file before implementation relies on them. Every plan and review must explicitly check compliance with these principles and document any justified exception.
 
-**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
-<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->
+**Version**: 1.0.0 | **Ratified**: 2026-03-14 | **Last Amended**: 2026-03-14

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,6 @@
 - Do not add production dependencies to `.csproj` without asking first
 - Changes to `openapi.yml` require updating `speckit.spec` in the same session
 - Commit work in smaller increments during task execution instead of waiting for a large final commit
-- Push the branch after completing each `speckit.tasks` task and verifying the required checks
 
 ## Active Technologies
 - C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling (001-add-trip-api)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,3 +67,12 @@
 - One task from `speckit.tasks` per session — no scope creep
 - Do not add production dependencies to `.csproj` without asking first
 - Changes to `openapi.yml` require updating `speckit.spec` in the same session
+- Commit work in smaller increments during task execution instead of waiting for a large final commit
+- Push the branch after completing each `speckit.tasks` task and verifying the required checks
+
+## Active Technologies
+- C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling (001-add-trip-api)
+- Entity Framework in-memory database for the current phase (001-add-trip-api)
+
+## Recent Changes
+- 001-add-trip-api: Added C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@
 - One task from `speckit.tasks` per session — no scope creep
 - Do not add production dependencies to `.csproj` without asking first
 - Changes to `openapi.yml` require updating `speckit.spec` in the same session
-- Commit work in smaller increments during task execution instead of waiting for a large final commit
+- Commit work in smaller increments during task execution instead of waiting for a large final commit.
+- Use $git-workflow to apply this repository's branch, commit, push, and PR conventions.
 
 ## Active Technologies
 - C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling (001-add-trip-api)

--- a/Maletapp.sln
+++ b/Maletapp.sln
@@ -5,6 +5,10 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trip.API", "src\Trip.API\Trip.API.csproj", "{EFEE31A3-A29E-4F8C-8D74-237EF7E41266}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trip.API.UnitTests", "tests\Trip.API.UnitTests\Trip.API.UnitTests.csproj", "{D5D0175A-5EA4-4938-85FA-AF27DC2036EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Trip.API.IntegrationTests", "tests\Trip.API.IntegrationTests\Trip.API.IntegrationTests.csproj", "{BEE6E3B0-9903-472F-A1F4-14F34914811B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +22,13 @@ Global
 		{EFEE31A3-A29E-4F8C-8D74-237EF7E41266}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EFEE31A3-A29E-4F8C-8D74-237EF7E41266}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EFEE31A3-A29E-4F8C-8D74-237EF7E41266}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D5D0175A-5EA4-4938-85FA-AF27DC2036EF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D5D0175A-5EA4-4938-85FA-AF27DC2036EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5D0175A-5EA4-4938-85FA-AF27DC2036EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D5D0175A-5EA4-4938-85FA-AF27DC2036EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BEE6E3B0-9903-472F-A1F4-14F34914811B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BEE6E3B0-9903-472F-A1F4-14F34914811B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BEE6E3B0-9903-472F-A1F4-14F34914811B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BEE6E3B0-9903-472F-A1F4-14F34914811B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/link-prompts.sh
+++ b/link-prompts.sh
@@ -4,3 +4,8 @@ ln -s "$(pwd)/.codex/prompts/speckit.specify.md"      ~/.codex/prompts/speckit.s
 ln -s "$(pwd)/.codex/prompts/speckit.plan.md"         ~/.codex/prompts/speckit.plan.md
 ln -s "$(pwd)/.codex/prompts/speckit.tasks.md"        ~/.codex/prompts/speckit.tasks.md
 ln -s "$(pwd)/.codex/prompts/speckit.implement.md"    ~/.codex/prompts/speckit.implement.md
+
+ln -s "$(pwd)/.codex/prompts/speckit.analyze.md"    ~/.codex/prompts/speckit.analyze.md
+ln -s "$(pwd)/.codex/prompts/speckit.checklist.md"    ~/.codex/prompts/speckit.checklist.md
+ln -s "$(pwd)/.codex/prompts/speckit.clarify.md"    ~/.codex/prompts/speckit.clarify.md
+ln -s "$(pwd)/.codex/prompts/speckit.taskstoissues.md"    ~/.codex/prompts/speckit.taskstoissues.md

--- a/specs/001-add-trip-api/checklists/requirements.md
+++ b/specs/001-add-trip-api/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Trip API Bootstrap
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-14
+**Feature**: [spec.md](/home/sicor/local-repos/maletapp/specs/001-add-trip-api/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed on 2026-03-14; no outstanding specification issues were found.

--- a/specs/001-add-trip-api/contracts/trips.md
+++ b/specs/001-add-trip-api/contracts/trips.md
@@ -1,0 +1,50 @@
+# Trip API Contract Summary
+
+Source of truth: [trip.yml](/home/sicor/local-repos/maletapp/spec/trip.yml)
+
+## Endpoints
+
+### `POST /trips` (`createTrip`)
+
+- Purpose: Create a new trip for the current user.
+- Request body:
+  - `destination`: required string
+  - `startDate`: optional date
+  - `endDate`: optional date
+- Success response:
+  - `201 Created`
+  - Response body contains trip `id`, `destination`, `startDate`, and `endDate`
+- Failure outcomes:
+  - `400 Bad Request` for invalid input
+  - `401 Unauthorized` when no current user can be resolved
+  - `500 Internal Server Error` for unexpected failures
+
+### `GET /trips` (`getTrips`)
+
+- Purpose: Retrieve the current user's trip list.
+- Success response:
+  - `200 OK`
+  - Response body is an array of trip objects
+- Failure outcomes:
+  - `401 Unauthorized` when no current user can be resolved
+  - `500 Internal Server Error` for unexpected failures
+
+### `GET /trips/{tripId}` (`getTripById`)
+
+- Purpose: Retrieve a single trip by identifier for the current user.
+- Path parameter:
+  - `tripId`: required UUID string
+- Success response:
+  - `200 OK`
+  - Response body contains trip `id`, `destination`, `startDate`, and `endDate`
+- Failure outcomes:
+  - `401 Unauthorized` when no current user can be resolved
+  - `403 Forbidden` when the trip exists but belongs to another user
+  - `404 Not Found` when the trip does not exist
+  - `500 Internal Server Error` for unexpected failures
+
+## Ownership Rules
+
+- Trip creation always assigns ownership to the current user.
+- Trip list results include only trips owned by the current user.
+- Trip detail access is restricted to the owning user.

--- a/specs/001-add-trip-api/data-model.md
+++ b/specs/001-add-trip-api/data-model.md
@@ -1,0 +1,54 @@
+# Data Model: Trip API Bootstrap
+
+## Trip
+
+- Purpose: Represents a travel plan owned by a single user.
+- Fields:
+  - `Id`: Unique trip identifier.
+  - `OwnerId`: User identifier for ownership and filtering.
+  - `Destination`: Required trip destination.
+  - `StartDate`: Optional trip start date.
+  - `EndDate`: Optional trip end date.
+- Relationships:
+  - Many trips can belong to one user identity.
+- Validation rules:
+  - `Destination` is required and cannot be blank.
+  - `StartDate` may be omitted.
+  - `EndDate` may be omitted.
+  - If both dates are present, `StartDate` must be on or before `EndDate`.
+- State transitions:
+  - Created: Trip is instantiated and persisted for the current user.
+  - Retrieved in list: Trip appears only in the owning user's collection view.
+  - Retrieved in detail: Trip is returned only when the current user owns it.
+
+## Current User Context
+
+- Purpose: Represents the user identity available for the active request.
+- Fields:
+  - `UserId`: Unique identifier used to scope trip creation and retrieval.
+- Relationships:
+  - One current-user context maps to zero or more owned trips.
+- Validation rules:
+  - A request without a determinable user identity is invalid for all trip endpoints in this feature.
+
+## Request and Response Shapes
+
+### New Trip Input
+
+- Fields:
+  - `Destination`: Required text value.
+  - `StartDate`: Optional calendar date.
+  - `EndDate`: Optional calendar date.
+- Validation rules:
+  - Input must include `Destination`.
+  - Date ordering must be valid when both dates are provided.
+
+### Trip Output
+
+- Fields:
+  - `Id`
+  - `Destination`
+  - `StartDate`
+  - `EndDate`
+- Notes:
+  - Ownership metadata is enforced by the system but is not required in the public response for this phase.

--- a/specs/001-add-trip-api/plan.md
+++ b/specs/001-add-trip-api/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: Trip API Bootstrap
+
+**Branch**: `001-add-trip-api` | **Date**: 2026-03-14 | **Spec**: [spec.md](/home/sicor/local-repos/maletapp/specs/001-add-trip-api/spec.md)
+**Input**: Feature specification from `/specs/001-add-trip-api/spec.md`
+
+## Summary
+
+Implement the first Trips API slice for creating trips, listing the current user's trips, and retrieving a trip by identifier. The implementation will use Minimal API endpoints over a repository-based application structure, Entity Framework with an in-memory database provider for this phase, a current-user accessor abstraction for ownership, and both unit and integration tests.
+
+## Technical Context
+
+**Language/Version**: C# with .NET 10 (`net10.0`)  
+**Primary Dependencies**: ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling  
+**Storage**: Entity Framework in-memory database for the current phase  
+**Testing**: .NET test runner with unit tests for domain/application behavior and integration tests for HTTP endpoints and persistence wiring  
+**Target Platform**: Linux-hosted ASP.NET Core web service  
+**Project Type**: Web service  
+**Performance Goals**: Support local development and automated test execution for the trip bootstrap flows with no perceptible latency in manual verification  
+**Constraints**: Preserve trip/item domain separation, use repository abstractions, rely on current-user accessor instead of implementing authentication flow, and keep warnings at zero  
+**Scale/Scope**: Initial MVP for one sub-API with 3 trip endpoints, one aggregate root, and isolated ownership rules
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- `Contract-First Delivery`: Pass. The plan is derived from [spec.md](/home/sicor/local-repos/maletapp/specs/001-add-trip-api/spec.md) and remains aligned with [trip.yml](/home/sicor/local-repos/maletapp/spec/trip.yml).
+- `Domain Separation`: Pass. This phase touches only Trips and does not introduce item-domain dependencies.
+- `Repository and Persistence Discipline`: Pass. The design uses repository abstractions with Entity Framework and an in-memory provider.
+- `Testable by Default`: Pass. The plan includes both unit and integration test suites.
+- `Operational Consistency`: Pass. The design uses Minimal API behavior, current-user access checks, and problem-details-oriented failures.
+
+Post-design re-check: Pass. The generated research, data model, contracts, and quickstart artifacts do not introduce constitutional violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-add-trip-api/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── Trip.API/
+    ├── Domain/
+    │   ├── Entities/
+    │   └── Value-objects/
+    ├── Application/
+    │   ├── Abstractions/
+    │   ├── Dtos/
+    │   └── Trips/
+    ├── Infrastructure/
+    │   ├── Persistence/
+    │   ├── Repositories/
+    │   └── UserContext/
+    └── Api/
+        └── Trips/
+
+tests/
+├── Trip.API.UnitTests/
+└── Trip.API.IntegrationTests/
+```
+
+**Structure Decision**: Keep a single deployable API project and add internal application and infrastructure folders inside `src/Trip.API` to avoid unnecessary project sprawl at this stage. Add separate unit and integration test projects under `tests/` so domain/application behavior and API wiring can evolve independently.
+
+## Complexity Tracking
+
+No constitutional violations or justified exceptions are required for this plan.

--- a/specs/001-add-trip-api/plan.md
+++ b/specs/001-add-trip-api/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Implement the first Trips API slice for creating trips, listing the current user's trips, and retrieving a trip by identifier. The implementation will use Minimal API endpoints over a repository-based application structure, Entity Framework with an in-memory database provider for this phase, a current-user accessor abstraction for ownership, and both unit and integration tests.
+Implement the first Trips API slice for creating trips, listing the current user's trips, and retrieving a trip by identifier. The implementation will use Minimal API endpoints over a repository-based application structure, Entity Framework with an in-memory database provider for this phase, a current-user accessor abstraction for ownership, explicit `CancellationToken` propagation across endpoints, handlers, and repositories, structured logging for trip operations and failures, and both unit and integration tests.
 
 ## Technical Context
 
@@ -16,7 +16,7 @@ Implement the first Trips API slice for creating trips, listing the current user
 **Target Platform**: Linux-hosted ASP.NET Core web service  
 **Project Type**: Web service  
 **Performance Goals**: Support local development and automated test execution for the trip bootstrap flows with no perceptible latency in manual verification  
-**Constraints**: Preserve trip/item domain separation, use repository abstractions, rely on current-user accessor instead of implementing authentication flow, and keep warnings at zero  
+**Constraints**: Preserve trip/item domain separation, use repository abstractions, rely on current-user accessor instead of implementing authentication flow, propagate `CancellationToken` from Minimal API endpoints through handlers and repositories, use structured logging instead of console output, and keep warnings at zero  
 **Scale/Scope**: Initial MVP for one sub-API with 3 trip endpoints, one aggregate root, and isolated ownership rules
 
 ## Constitution Check
@@ -27,7 +27,7 @@ Implement the first Trips API slice for creating trips, listing the current user
 - `Domain Separation`: Pass. This phase touches only Trips and does not introduce item-domain dependencies.
 - `Repository and Persistence Discipline`: Pass. The design uses repository abstractions with Entity Framework and an in-memory provider.
 - `Testable by Default`: Pass. The plan includes both unit and integration test suites.
-- `Operational Consistency`: Pass. The design uses Minimal API behavior, current-user access checks, and problem-details-oriented failures.
+- `Operational Consistency`: Pass. The design uses Minimal API behavior, explicit `CancellationToken` propagation, structured logging, current-user access checks, and problem-details-oriented failures.
 
 Post-design re-check: Pass. The generated research, data model, contracts, and quickstart artifacts do not introduce constitutional violations.
 

--- a/specs/001-add-trip-api/quickstart.md
+++ b/specs/001-add-trip-api/quickstart.md
@@ -1,0 +1,34 @@
+# Quickstart: Trip API Bootstrap
+
+## Goal
+
+Implement the first Trips API slice so a current user can create trips, list their trips, and fetch a trip detail using a repository-backed Entity Framework in-memory store.
+
+## Implementation Sequence
+
+1. Replace the starter endpoint in `src/Trip.API/Program.cs` with trip endpoint registration and common middleware.
+2. Add application abstractions for trip repository access and current-user access.
+3. Add or align the trip domain model so destination and date validation match the feature spec and contract.
+4. Add Entity Framework persistence with an in-memory database and a repository implementation for trips.
+5. Add request and response DTOs for `createTrip`, `getTrips`, and `getTripById`.
+6. Add endpoint handlers that resolve the current user, call application logic, and return contract-aligned responses.
+7. Add typed failure handling so invalid input, unauthorized access, forbidden access, and not-found cases return problem details.
+8. Add unit tests for trip validation and application behavior.
+9. Add integration tests that exercise the three HTTP endpoints against the in-memory data store.
+
+## Verification
+
+1. Run `dotnet build --no-incremental`.
+2. Run `dotnet test --no-build`.
+3. Run `dotnet format --verify-no-changes`.
+4. Manually verify Swagger or HTTP calls for:
+   - creating a trip with required destination
+   - listing only the current user's trips
+   - retrieving an owned trip by id
+   - receiving failure responses for invalid input, missing user context, foreign trip access, and missing trips
+
+## Notes
+
+- Keep authentication implementation out of scope; use a replaceable current-user accessor.
+- Keep Items and Trips isolated.
+- Treat the in-memory database as a temporary infrastructure choice for this phase, not a long-term domain assumption.

--- a/specs/001-add-trip-api/research.md
+++ b/specs/001-add-trip-api/research.md
@@ -1,0 +1,31 @@
+# Research: Trip API Bootstrap
+
+## Decision 1: Use repository abstractions backed by Entity Framework
+
+- Decision: Introduce repository interfaces for trip persistence and implement them with Entity Framework in infrastructure code.
+- Rationale: This satisfies the requested repository pattern, keeps API/application code independent from persistence details, and preserves the option to replace the in-memory store later without reshaping endpoint behavior.
+- Alternatives considered: Direct `DbContext` usage from endpoints was rejected because it couples API handlers to storage concerns. A custom in-memory collection repository was rejected because you explicitly requested Entity Framework, and it would not exercise the intended persistence wiring.
+
+## Decision 2: Use EF Core InMemory as the storage provider for the current phase
+
+- Decision: Configure Entity Framework to use the in-memory provider for local execution and automated tests in this feature phase.
+- Rationale: It meets the requested short-term storage approach, keeps setup friction low, and supports fast integration tests for the three trip endpoints.
+- Alternatives considered: SQLite in-memory was rejected because the requirement is specifically to start with an in-memory database using Entity Framework and not add extra persistence behavior yet. A durable relational database was rejected because it exceeds the current scope.
+
+## Decision 3: Keep authentication out of scope and use a current-user accessor abstraction
+
+- Decision: Model the current user as an accessor abstraction consumed by endpoints and application services, with integration tests supplying deterministic identities.
+- Rationale: The spec explicitly says the auth flow is not defined yet, but ownership and filtering behavior still depend on a current user. An accessor abstraction lets the feature proceed without hard-coding an auth mechanism.
+- Alternatives considered: Implementing bearer-token authentication was rejected because it would expand scope into undefined security flows. Using a global static test user was rejected because it would hide ownership behavior and make tests less representative.
+
+## Decision 4: Test at two levels
+
+- Decision: Add unit tests for trip creation rules and ownership-oriented application behavior, plus integration tests covering the HTTP contract for create, list, and detail flows.
+- Rationale: The constitution requires both unit and integration tests, and the split gives faster feedback for domain rules while still validating endpoint wiring, serialization, problem responses, and persistence behavior.
+- Alternatives considered: Integration tests only were rejected because domain validation and repository interactions would be slower to isolate. Unit tests only were rejected because they would not verify the externally visible API behavior.
+
+## Decision 5: Keep the implementation inside the existing API project
+
+- Decision: Implement the application, infrastructure, and endpoint folders inside `src/Trip.API` instead of creating multiple production projects in this phase.
+- Rationale: The repository is currently a single API project. Preserving that shape minimizes churn while still allowing clean layering through folders and abstractions.
+- Alternatives considered: Splitting into multiple production projects now was rejected because it adds structural overhead before the feature surface justifies it.

--- a/specs/001-add-trip-api/spec.md
+++ b/specs/001-add-trip-api/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Trip API Bootstrap
+
+**Feature Branch**: `001-add-trip-api`  
+**Created**: 2026-03-14  
+**Status**: Draft  
+**Input**: User description: "I want a trip API to manage my List of items to carry with me. For the very beginning i want to create trips, retrieve my trips list and get a trip detail. Follow the spec/trip.yml to start. The current user should be retrieved for a UserContextAccessor, however the auth flow and method is not defined yet."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Create a trip (Priority: P1)
+
+As a traveler, I want to create a trip with its destination and optional travel dates so I can start organizing what I need to carry for that trip.
+
+**Why this priority**: Trip creation is the entry point for all later trip-based planning. Without it, the rest of the feature set has no value.
+
+**Independent Test**: Can be fully tested by submitting a new trip for the current user and confirming the trip is stored and returned with a unique identifier.
+
+**Acceptance Scenarios**:
+
+1. **Given** an identified current user, **When** the user creates a trip with a destination, **Then** the system creates the trip under that user and returns the created trip with its identifier and saved fields.
+2. **Given** an identified current user, **When** the user creates a trip without travel dates, **Then** the system accepts the trip and stores the dates as unspecified.
+3. **Given** an identified current user, **When** the user creates a trip without a destination, **Then** the system rejects the request and explains that destination is required.
+
+---
+
+### User Story 2 - View my trip list (Priority: P2)
+
+As a traveler, I want to retrieve my trips so I can see what trips I have already created and choose one to continue planning.
+
+**Why this priority**: Once trips exist, listing them is the fastest way for a user to resume work and verify that creation succeeded.
+
+**Independent Test**: Can be fully tested by retrieving the current user's trip list and verifying it contains only that user's trips.
+
+**Acceptance Scenarios**:
+
+1. **Given** an identified current user with multiple trips, **When** the user requests their trip list, **Then** the system returns all trips owned by that user.
+2. **Given** an identified current user with no trips, **When** the user requests their trip list, **Then** the system returns an empty list.
+
+---
+
+### User Story 3 - View a trip detail (Priority: P3)
+
+As a traveler, I want to retrieve the details of a specific trip so I can confirm its destination and dates before adding or reviewing trip-related items.
+
+**Why this priority**: Trip detail supports follow-up planning and validation, but depends on trips already existing.
+
+**Independent Test**: Can be fully tested by requesting a trip by identifier and verifying the returned record matches the selected trip and ownership rules.
+
+**Acceptance Scenarios**:
+
+1. **Given** an identified current user and one of their existing trips, **When** the user requests that trip by identifier, **Then** the system returns the trip details.
+2. **Given** an identified current user, **When** the user requests a trip that does not exist, **Then** the system reports that the trip was not found.
+3. **Given** an identified current user, **When** the user requests a trip owned by a different user, **Then** the system denies access to that trip.
+
+### Edge Cases
+
+- A user creates a trip with only the required destination and omits both dates.
+- A user creates a trip with a start date later than the end date.
+- A user requests their trip list before any trips have been created.
+- A user requests a trip using an invalid trip identifier format.
+- A user requests a trip that exists but is owned by another user.
+- The system cannot determine the current user for the request.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow the current user to create a trip with a required destination and optional start date and end date.
+- **FR-002**: The system MUST assign each created trip a unique identifier.
+- **FR-003**: The system MUST associate each created trip with the current user who created it.
+- **FR-004**: The system MUST reject trip creation when the required destination is missing.
+- **FR-005**: The system MUST reject trip creation when provided travel dates are invalid, including when the start date is later than the end date.
+- **FR-006**: The system MUST allow the current user to retrieve a list of only the trips associated with that user.
+- **FR-007**: The system MUST return an empty result when the current user has no trips.
+- **FR-008**: The system MUST allow the current user to retrieve the details of a single trip by its identifier.
+- **FR-009**: The system MUST deny access when a user requests a trip owned by a different user.
+- **FR-010**: The system MUST report when a requested trip does not exist.
+- **FR-011**: The system MUST reject requests that do not have a determinable current user.
+- **FR-012**: The system MUST preserve the trip fields defined for this phase: identifier, destination, start date, and end date.
+
+### Key Entities *(include if feature involves data)*
+
+- **Trip**: A travel plan owned by one user, identified uniquely, with a destination and optional start and end dates.
+- **Current User Context**: The request-scoped user identity used to determine ownership, access to trips, and which trips appear in list results.
+
+### Assumptions
+
+- The feature scope for this first phase is limited to creating trips, listing the current user's trips, and retrieving one trip detail.
+- A valid current user identity is made available to the system for each authenticated request, but the authentication flow itself is outside this feature's scope.
+- Ownership is enforced per trip so users can only view trips they own.
+- No trip update, deletion, item management, sharing, or collaboration behavior is included in this phase.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can create a trip with the required destination in a single submission.
+- **SC-002**: In validation testing, 100% of created trips appear in the creating user's trip list and do not appear in any other user's trip list.
+- **SC-003**: In validation testing, 100% of successful trip detail requests return the correct destination and dates for the requested trip.
+- **SC-004**: In validation testing, 100% of requests for missing trips, unauthorized trip access, invalid trip identifiers, or missing current-user context return a clear failure outcome instead of an ambiguous or empty success response.

--- a/specs/001-add-trip-api/tasks.md
+++ b/specs/001-add-trip-api/tasks.md
@@ -17,10 +17,10 @@
 
 **Purpose**: Create the project and test scaffolding required by the plan
 
-- [ ] T001 Add Entity Framework and testing package references in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.csproj`
-- [ ] T002 [P] Create the unit test project definition in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj`
-- [ ] T003 [P] Create the integration test project definition in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj`
-- [ ] T004 Add the API and test projects to `/home/sicor/local-repos/maletapp/Maletapp.sln`
+- [X] T001 Add Entity Framework and testing package references in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.csproj`
+- [X] T002 [P] Create the unit test project definition in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj`
+- [X] T003 [P] Create the integration test project definition in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj`
+- [X] T004 Add the API and test projects to `/home/sicor/local-repos/maletapp/Maletapp.sln`
 
 ---
 
@@ -30,18 +30,18 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T005 Create repository and current-user abstraction interfaces in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/IUserContextAccessor.cs`
-- [ ] T006 [P] Create shared trip DTOs in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/TripDto.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/NewTripDto.cs`
-- [ ] T007 [P] Create typed application exceptions in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/NotFoundException.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/ForbiddenException.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/UnauthorizedException.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/ValidationException.cs`
-- [ ] T008 Align the trip domain entity rules in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Trip.cs`
-- [ ] T009 [P] Create Entity Framework persistence primitives in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs`
-- [ ] T010 [P] Create the Entity Framework trip repository in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
-- [ ] T011 [P] Create the request user-context implementation in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/UserContext/HttpUserContextAccessor.cs`
-- [ ] T012 Replace the starter bootstrap with service registration, problem details, and trip endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
-- [ ] T013 [P] Add OpenAPI endpoint naming constants or verification notes for `createTrip`, `getTrips`, and `getTripById` in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
-- [ ] T014 [P] Add explicit `CancellationToken` support to repository interfaces, application handlers, and endpoint signatures in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
-- [ ] T015 [P] Add structured logging dependencies and shared logging patterns for trip operations in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
-- [ ] T016 [P] Add integration test infrastructure helpers in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs`
+- [X] T005 Create repository and current-user abstraction interfaces in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/IUserContextAccessor.cs`
+- [X] T006 [P] Create shared trip DTOs in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/TripDto.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/NewTripDto.cs`
+- [X] T007 [P] Create typed application exceptions in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/NotFoundException.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/ForbiddenException.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/UnauthorizedException.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/ValidationException.cs`
+- [X] T008 Align the trip domain entity rules in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Trip.cs`
+- [X] T009 [P] Create Entity Framework persistence primitives in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs`
+- [X] T010 [P] Create the Entity Framework trip repository in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [X] T011 [P] Create the request user-context implementation in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/UserContext/HttpUserContextAccessor.cs`
+- [X] T012 Replace the starter bootstrap with service registration, problem details, and trip endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
+- [X] T013 [P] Add OpenAPI endpoint naming constants or verification notes for `createTrip`, `getTrips`, and `getTripById` in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
+- [X] T014 [P] Add explicit `CancellationToken` support to repository interfaces, application handlers, and endpoint signatures in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
+- [X] T015 [P] Add structured logging dependencies and shared logging patterns for trip operations in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
+- [X] T016 [P] Add integration test infrastructure helpers in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin
 
@@ -55,16 +55,16 @@
 
 ### Tests for User Story 1
 
-- [ ] T017 [P] [US1] Add trip domain validation unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/TripTests.cs`
-- [ ] T018 [P] [US1] Add create-trip application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs`
-- [ ] T019 [P] [US1] Add create-trip integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/CreateTripEndpointTests.cs`
+- [X] T017 [P] [US1] Add trip domain validation unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/TripTests.cs`
+- [X] T018 [P] [US1] Add create-trip application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs`
+- [X] T019 [P] [US1] Add create-trip integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/CreateTripEndpointTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T020 [P] [US1] Create the create-trip request and response models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripRequest.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/TripResponse.cs`
-- [ ] T021 [P] [US1] Create create-trip application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripResult.cs`
-- [ ] T022 [US1] Implement create-trip application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripHandler.cs`
-- [ ] T023 [US1] Implement the `createTrip` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripEndpoint.cs`
+- [X] T020 [P] [US1] Create the create-trip request and response models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripRequest.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/TripResponse.cs`
+- [X] T021 [P] [US1] Create create-trip application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripResult.cs`
+- [X] T022 [US1] Implement create-trip application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripHandler.cs`
+- [X] T023 [US1] Implement the `createTrip` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripEndpoint.cs`
 
 **Checkpoint**: User Story 1 should be fully functional and testable independently
 
@@ -78,14 +78,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T024 [P] [US2] Add list-trips application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs`
-- [ ] T025 [P] [US2] Add list-trips integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripsEndpointTests.cs`
+- [X] T024 [P] [US2] Add list-trips application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs`
+- [X] T025 [P] [US2] Add list-trips integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripsEndpointTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T026 [P] [US2] Create list-trips application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsResult.cs`
-- [ ] T027 [US2] Implement list-trips application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsHandler.cs`
-- [ ] T028 [US2] Implement the `getTrips` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/GetTripsEndpoint.cs`
+- [X] T026 [P] [US2] Create list-trips application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsResult.cs`
+- [X] T027 [US2] Implement list-trips application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsHandler.cs`
+- [X] T028 [US2] Implement the `getTrips` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/GetTripsEndpoint.cs`
 
 **Checkpoint**: User Stories 1 and 2 should both work independently
 
@@ -99,14 +99,14 @@
 
 ### Tests for User Story 3
 
-- [ ] T029 [P] [US3] Add get-trip-detail application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs`
-- [ ] T030 [P] [US3] Add get-trip-detail integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripByIdEndpointTests.cs`
+- [X] T029 [P] [US3] Add get-trip-detail application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs`
+- [X] T030 [P] [US3] Add get-trip-detail integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripByIdEndpointTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T031 [P] [US3] Create get-trip-detail application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdResult.cs`
-- [ ] T032 [US3] Implement get-trip-detail application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdHandler.cs`
-- [ ] T033 [US3] Implement the `getTripById` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/GetTripByIdEndpoint.cs`
+- [X] T031 [P] [US3] Create get-trip-detail application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdResult.cs`
+- [X] T032 [US3] Implement get-trip-detail application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdHandler.cs`
+- [X] T033 [US3] Implement the `getTripById` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/GetTripByIdEndpoint.cs`
 
 **Checkpoint**: All user stories should now be independently functional
 
@@ -116,9 +116,9 @@
 
 **Purpose**: Final cross-story cleanup and verification
 
-- [ ] T034 [P] Add unit test shared fixtures in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
-- [ ] T035 Update API example configuration for current-user testing in `/home/sicor/local-repos/maletapp/src/Trip.API/appsettings.Development.json`
-- [ ] T036 Run the full verification flow from `/home/sicor/local-repos/maletapp/specs/001-add-trip-api/quickstart.md`
+- [X] T034 [P] Add unit test shared fixtures in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
+- [X] T035 Update API example configuration for current-user testing in `/home/sicor/local-repos/maletapp/src/Trip.API/appsettings.Development.json`
+- [X] T036 Run the full verification flow from `/home/sicor/local-repos/maletapp/specs/001-add-trip-api/quickstart.md`
 
 ---
 

--- a/specs/001-add-trip-api/tasks.md
+++ b/specs/001-add-trip-api/tasks.md
@@ -1,0 +1,219 @@
+# Tasks: Trip API Bootstrap
+
+**Input**: Design documents from `/specs/001-add-trip-api/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Unit and integration tests are required for this feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the project and test scaffolding required by the plan
+
+- [ ] T001 Add Entity Framework and testing package references in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.csproj`
+- [ ] T002 [P] Create the unit test project definition in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj`
+- [ ] T003 [P] Create the integration test project definition in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj`
+- [ ] T004 Add the API and test projects to `/home/sicor/local-repos/maletapp/Maletapp.sln`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before any user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T005 Create repository and current-user abstraction interfaces in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/IUserContextAccessor.cs`
+- [ ] T006 [P] Create shared trip DTOs in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/TripDto.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/NewTripDto.cs`
+- [ ] T007 [P] Create typed application exceptions in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/NotFoundException.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/ForbiddenException.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/UnauthorizedException.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Exceptions/ValidationException.cs`
+- [ ] T008 Align the trip domain entity rules in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Trip.cs`
+- [ ] T009 [P] Create Entity Framework persistence primitives in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs`
+- [ ] T010 [P] Create the Entity Framework trip repository in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [ ] T011 [P] Create the request user-context implementation in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/UserContext/HttpUserContextAccessor.cs`
+- [ ] T012 Replace the starter bootstrap with service registration, problem details, and trip endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
+- [ ] T013 [P] Add OpenAPI endpoint naming constants or verification notes for `createTrip`, `getTrips`, and `getTripById` in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
+- [ ] T014 [P] Add explicit `CancellationToken` support to repository interfaces, application handlers, and endpoint signatures in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
+- [ ] T015 [P] Add structured logging dependencies and shared logging patterns for trip operations in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/`
+- [ ] T016 [P] Add integration test infrastructure helpers in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Create a trip (Priority: P1) 🎯 MVP
+
+**Goal**: Allow the current user to create a trip with destination and optional dates
+
+**Independent Test**: Submit a create-trip request and verify the response contains a new identifier, the saved fields, and the trip belongs to the current user; verify invalid input and missing-user failures
+
+### Tests for User Story 1
+
+- [ ] T017 [P] [US1] Add trip domain validation unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/TripTests.cs`
+- [ ] T018 [P] [US1] Add create-trip application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs`
+- [ ] T019 [P] [US1] Add create-trip integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/CreateTripEndpointTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T020 [P] [US1] Create the create-trip request and response models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripRequest.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/TripResponse.cs`
+- [ ] T021 [P] [US1] Create create-trip application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripResult.cs`
+- [ ] T022 [US1] Implement create-trip application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripHandler.cs`
+- [ ] T023 [US1] Implement the `createTrip` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripEndpoint.cs`
+
+**Checkpoint**: User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - View my trip list (Priority: P2)
+
+**Goal**: Return only the current user's trips, including the empty-list case
+
+**Independent Test**: Seed trips for multiple users and verify the trip list returns only the current user's trips, or an empty list when none exist
+
+### Tests for User Story 2
+
+- [ ] T024 [P] [US2] Add list-trips application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs`
+- [ ] T025 [P] [US2] Add list-trips integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripsEndpointTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T026 [P] [US2] Create list-trips application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsResult.cs`
+- [ ] T027 [US2] Implement list-trips application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsHandler.cs`
+- [ ] T028 [US2] Implement the `getTrips` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/GetTripsEndpoint.cs`
+
+**Checkpoint**: User Stories 1 and 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - View a trip detail (Priority: P3)
+
+**Goal**: Return a single owned trip and enforce not-found and forbidden access outcomes
+
+**Independent Test**: Request one owned trip by identifier and verify the detail response, then verify missing-trip, foreign-trip, invalid-id, and missing-user failures
+
+### Tests for User Story 3
+
+- [ ] T029 [P] [US3] Add get-trip-detail application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs`
+- [ ] T030 [P] [US3] Add get-trip-detail integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripByIdEndpointTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T031 [P] [US3] Create get-trip-detail application models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdResult.cs`
+- [ ] T032 [US3] Implement get-trip-detail application logic with `CancellationToken` support and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdHandler.cs`
+- [ ] T033 [US3] Implement the `getTripById` endpoint with the exact OpenAPI `operationId` name, `CancellationToken` parameter, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/GetTripByIdEndpoint.cs`
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cross-story cleanup and verification
+
+- [ ] T034 [P] Add unit test shared fixtures in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
+- [ ] T035 Update API example configuration for current-user testing in `/home/sicor/local-repos/maletapp/src/Trip.API/appsettings.Development.json`
+- [ ] T036 Run the full verification flow from `/home/sicor/local-repos/maletapp/specs/001-add-trip-api/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion; is the MVP
+- **User Story 2 (Phase 4)**: Depends on Foundational completion and can reuse the trip DTOs and repository from earlier phases
+- **User Story 3 (Phase 5)**: Depends on Foundational completion and can reuse the trip DTOs and repository from earlier phases
+- **Polish (Phase 6)**: Depends on all implemented user stories
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories
+- **US2**: No strict dependency on US1 for architecture, but practical verification benefits from at least one created trip
+- **US3**: No strict dependency on US2, but practical verification benefits from at least one created trip
+
+### Within Each User Story
+
+- Tests must be written before the corresponding implementation tasks
+- API request/response models before handlers when they share files
+- Application handlers before endpoints
+- Endpoint wiring must be complete before story verification
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel after T001
+- T006, T007, T009, T010, T011, T013, T014, T015, and T016 can run in parallel after T005 and T008 where applicable
+- For US1, T017, T018, T019, T020, and T021 can run in parallel before T022 and T023
+- For US2, T024, T025, and T026 can run in parallel before T027 and T028
+- For US3, T029, T030, and T031 can run in parallel before T032 and T033
+- T034 can run in parallel with other polish tasks
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add trip domain validation unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/TripTests.cs"
+Task: "Add create-trip application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs"
+Task: "Add create-trip integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/CreateTripEndpointTests.cs"
+Task: "Create the create-trip request and response models in /home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/CreateTripRequest.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Api/Trips/TripResponse.cs"
+Task: "Create create-trip application models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripCommand.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/CreateTrip/CreateTripResult.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add list-trips application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs"
+Task: "Add list-trips integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripsEndpointTests.cs"
+Task: "Create list-trips application models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsQuery.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTrips/GetTripsResult.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Add get-trip-detail application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs"
+Task: "Add get-trip-detail integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trips/GetTripByIdEndpointTests.cs"
+Task: "Create get-trip-detail application models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdQuery.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Trips/GetTripById/GetTripByIdResult.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate create-trip behavior independently
+5. Commit and push the completed task work
+
+### Incremental Delivery
+
+1. Complete Setup and Foundational work once
+2. Deliver US1 as the MVP
+3. Deliver US2 as the next independently testable increment
+4. Deliver US3 as the final functional increment
+5. Finish with cross-cutting verification and cleanup
+
+### Parallel Team Strategy
+
+1. One engineer handles test-project and solution setup while another prepares foundational abstractions
+2. After Phase 2, one engineer can handle US1 while others prepare US2 and US3 tests and query models
+3. Complete each story, verify it independently, then merge in priority order
+
+---
+
+## Notes
+
+- Every task follows the required checklist format with an ID, optional parallel marker, required story label for story work, and exact file paths
+- Tests are intentionally included because the user requested unit and integration coverage
+- US1 is the suggested MVP scope
+- Commit after each completed task or tight logical batch, then push after each completed `speckit.tasks` task per repository guidance

--- a/src/Trip.API/Api/ErrorHandling/GlobalExceptionHandler.cs
+++ b/src/Trip.API/Api/ErrorHandling/GlobalExceptionHandler.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Api.ErrorHandling;
+
+public sealed class GlobalExceptionHandler : IExceptionHandler
+{
+    private readonly ILogger<GlobalExceptionHandler> _logger;
+    private readonly IProblemDetailsService _problemDetailsService;
+
+    public GlobalExceptionHandler(
+        ILogger<GlobalExceptionHandler> logger,
+        IProblemDetailsService problemDetailsService)
+    {
+        _logger = logger;
+        _problemDetailsService = problemDetailsService;
+    }
+
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        var (statusCode, title) = exception switch
+        {
+            ValidationException => (StatusCodes.Status400BadRequest, "Bad Request"),
+            UnauthorizedException => (StatusCodes.Status401Unauthorized, "Unauthorized"),
+            ForbiddenException => (StatusCodes.Status403Forbidden, "Forbidden"),
+            NotFoundException => (StatusCodes.Status404NotFound, "Not Found"),
+            _ => (StatusCodes.Status500InternalServerError, "Internal Server Error")
+        };
+
+        if (statusCode >= StatusCodes.Status500InternalServerError)
+        {
+            _logger.LogError(exception, "Unhandled exception while processing {Method} {Path}", httpContext.Request.Method, httpContext.Request.Path);
+        }
+        else
+        {
+            _logger.LogWarning(exception, "Handled exception while processing {Method} {Path}", httpContext.Request.Method, httpContext.Request.Path);
+        }
+
+        httpContext.Response.StatusCode = statusCode;
+
+        return await _problemDetailsService.TryWriteAsync(new ProblemDetailsContext
+        {
+            HttpContext = httpContext,
+            ProblemDetails = new ProblemDetails
+            {
+                Status = statusCode,
+                Title = title,
+                Detail = exception.Message
+            }
+        }).ConfigureAwait(false);
+    }
+}

--- a/src/Trip.API/Api/Trips/CreateTripEndpoint.cs
+++ b/src/Trip.API/Api/Trips/CreateTripEndpoint.cs
@@ -1,0 +1,41 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Trips.CreateTrip;
+
+namespace Trip.API.Api.Trips;
+
+public static class CreateTripEndpoint
+{
+    public static IEndpointRouteBuilder MapCreateTrip(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost(
+                "/trips",
+                async Task<IResult> (
+                    CreateTripRequest request,
+                    IUserContextAccessor userContextAccessor,
+                    CreateTripHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(CreateTripEndpoint));
+                    logger.CreateTripRequestReceived(userId.Value);
+
+                    var result = await handler.HandleAsync(
+                        new CreateTripCommand(
+                            userId,
+                            new NewTripDto(request.Destination, request.StartDate, request.EndDate)),
+                        cancellationToken);
+
+                    var trip = result.Trip;
+                    return Results.Created($"/trips/{trip.Id}", new TripResponse(trip.Id, trip.Destination, trip.StartDate, trip.EndDate));
+                })
+            .WithName(TripEndpointNames.CreateTrip)
+            .WithTags("Trips");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Trips/CreateTripRequest.cs
+++ b/src/Trip.API/Api/Trips/CreateTripRequest.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Api.Trips;
+
+public sealed record CreateTripRequest(string Destination, DateOnly? StartDate, DateOnly? EndDate);

--- a/src/Trip.API/Api/Trips/GetTripByIdEndpoint.cs
+++ b/src/Trip.API/Api/Trips/GetTripByIdEndpoint.cs
@@ -1,0 +1,39 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Trips.GetTripById;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Api.Trips;
+
+public static class GetTripByIdEndpoint
+{
+    public static IEndpointRouteBuilder MapGetTripById(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(
+                "/trips/{tripId:guid}",
+                async Task<IResult> (
+                    Guid tripId,
+                    IUserContextAccessor userContextAccessor,
+                    GetTripByIdHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(GetTripByIdEndpoint));
+                    logger.GetTripByIdRequestReceived(userId.Value, tripId);
+
+                    var result = await handler.HandleAsync(
+                        new GetTripByIdQuery(userId, TripId.FromGuid(tripId)),
+                        cancellationToken);
+
+                    var trip = result.Trip;
+                    return Results.Ok(new TripResponse(trip.Id, trip.Destination, trip.StartDate, trip.EndDate));
+                })
+            .WithName(TripEndpointNames.GetTripById)
+            .WithTags("Trips");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Trips/GetTripsEndpoint.cs
+++ b/src/Trip.API/Api/Trips/GetTripsEndpoint.cs
@@ -1,0 +1,36 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Trips.GetTrips;
+
+namespace Trip.API.Api.Trips;
+
+public static class GetTripsEndpoint
+{
+    public static IEndpointRouteBuilder MapGetTrips(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(
+                "/trips",
+                async Task<IResult> (
+                    IUserContextAccessor userContextAccessor,
+                    GetTripsHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(GetTripsEndpoint));
+                    logger.GetTripsRequestReceived(userId.Value);
+
+                    var result = await handler.HandleAsync(new GetTripsQuery(userId), cancellationToken);
+                    var response = result.Trips
+                        .Select(trip => new TripResponse(trip.Id, trip.Destination, trip.StartDate, trip.EndDate));
+
+                    return Results.Ok(response);
+                })
+            .WithName(TripEndpointNames.GetTrips)
+            .WithTags("Trips");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Trips/TripEndpointNames.cs
+++ b/src/Trip.API/Api/Trips/TripEndpointNames.cs
@@ -1,0 +1,8 @@
+namespace Trip.API.Api.Trips;
+
+public static class TripEndpointNames
+{
+    public const string CreateTrip = "createTrip";
+    public const string GetTrips = "getTrips";
+    public const string GetTripById = "getTripById";
+}

--- a/src/Trip.API/Api/Trips/TripEndpointRouteBuilderExtensions.cs
+++ b/src/Trip.API/Api/Trips/TripEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,13 @@
+namespace Trip.API.Api.Trips;
+
+public static class TripEndpointRouteBuilderExtensions
+{
+    public static IEndpointRouteBuilder MapTripEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapCreateTrip();
+        endpoints.MapGetTrips();
+        endpoints.MapGetTripById();
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Trips/TripLogMessages.cs
+++ b/src/Trip.API/Api/Trips/TripLogMessages.cs
@@ -1,0 +1,13 @@
+namespace Trip.API.Api.Trips;
+
+internal static partial class TripLogMessages
+{
+    [LoggerMessage(EventId = 1000, Level = LogLevel.Information, Message = "Received create trip request for user {UserId}")]
+    public static partial void CreateTripRequestReceived(this ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = 1001, Level = LogLevel.Information, Message = "Received get trips request for user {UserId}")]
+    public static partial void GetTripsRequestReceived(this ILogger logger, Guid userId);
+
+    [LoggerMessage(EventId = 1002, Level = LogLevel.Information, Message = "Received get trip detail request for user {UserId} and trip {TripId}")]
+    public static partial void GetTripByIdRequestReceived(this ILogger logger, Guid userId, Guid tripId);
+}

--- a/src/Trip.API/Api/Trips/TripResponse.cs
+++ b/src/Trip.API/Api/Trips/TripResponse.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Api.Trips;
+
+public sealed record TripResponse(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);

--- a/src/Trip.API/Application/Abstractions/ITripRepository.cs
+++ b/src/Trip.API/Application/Abstractions/ITripRepository.cs
@@ -1,0 +1,14 @@
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.Application.Abstractions;
+
+public interface ITripRepository
+{
+    Task AddAsync(TripEntity trip, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken);
+
+    Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken);
+}

--- a/src/Trip.API/Application/Abstractions/IUserContextAccessor.cs
+++ b/src/Trip.API/Application/Abstractions/IUserContextAccessor.cs
@@ -1,0 +1,8 @@
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Abstractions;
+
+public interface IUserContextAccessor
+{
+    UserId? GetCurrentUserId();
+}

--- a/src/Trip.API/Application/Dtos/NewTripDto.cs
+++ b/src/Trip.API/Application/Dtos/NewTripDto.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Application.Dtos;
+
+public sealed record NewTripDto(string Destination, DateOnly? StartDate, DateOnly? EndDate);

--- a/src/Trip.API/Application/Dtos/TripDto.cs
+++ b/src/Trip.API/Application/Dtos/TripDto.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Application.Dtos;
+
+public sealed record TripDto(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);

--- a/src/Trip.API/Application/Exceptions/ForbiddenException.cs
+++ b/src/Trip.API/Application/Exceptions/ForbiddenException.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Application.Exceptions;
+
+public sealed class ForbiddenException : TripApiException
+{
+    public ForbiddenException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Trip.API/Application/Exceptions/NotFoundException.cs
+++ b/src/Trip.API/Application/Exceptions/NotFoundException.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Application.Exceptions;
+
+public sealed class NotFoundException : TripApiException
+{
+    public NotFoundException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Trip.API/Application/Exceptions/TripApiException.cs
+++ b/src/Trip.API/Application/Exceptions/TripApiException.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Application.Exceptions;
+
+public abstract class TripApiException : Exception
+{
+    protected TripApiException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Trip.API/Application/Exceptions/UnauthorizedException.cs
+++ b/src/Trip.API/Application/Exceptions/UnauthorizedException.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Application.Exceptions;
+
+public sealed class UnauthorizedException : TripApiException
+{
+    public UnauthorizedException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Trip.API/Application/Exceptions/ValidationException.cs
+++ b/src/Trip.API/Application/Exceptions/ValidationException.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Application.Exceptions;
+
+public sealed class ValidationException : TripApiException
+{
+    public ValidationException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/Trip.API/Application/Trips/CreateTrip/CreateTripCommand.cs
+++ b/src/Trip.API/Application/Trips/CreateTrip/CreateTripCommand.cs
@@ -1,0 +1,6 @@
+using Trip.API.Application.Dtos;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Trips.CreateTrip;
+
+public sealed record CreateTripCommand(UserId UserId, NewTripDto NewTrip);

--- a/src/Trip.API/Application/Trips/CreateTrip/CreateTripHandler.cs
+++ b/src/Trip.API/Application/Trips/CreateTrip/CreateTripHandler.cs
@@ -1,0 +1,61 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.Application.Trips.CreateTrip;
+
+public sealed class CreateTripHandler
+{
+    private readonly ILogger<CreateTripHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public CreateTripHandler(ITripRepository tripRepository, ILogger<CreateTripHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<CreateTripResult> HandleAsync(CreateTripCommand command, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(command.NewTrip.Destination))
+        {
+            throw new ValidationException("Trip destination is required.");
+        }
+
+        if (command.NewTrip.StartDate.HasValue
+            && command.NewTrip.EndDate.HasValue
+            && command.NewTrip.StartDate > command.NewTrip.EndDate)
+        {
+            throw new ValidationException("Trip start date cannot be after end date.");
+        }
+
+        var trip = new TripEntity(
+            TripId.CreateUnique(),
+            command.UserId,
+            command.NewTrip.Destination,
+            command.NewTrip.StartDate,
+            command.NewTrip.EndDate);
+
+        _logger.LogInformation(
+            "Creating trip {TripId} for user {UserId} heading to {Destination}",
+            trip.Id.Value,
+            command.UserId.Value,
+            trip.Destination);
+
+        await _tripRepository.AddAsync(trip, cancellationToken).ConfigureAwait(false);
+
+        return new CreateTripResult(MapTrip(trip));
+    }
+
+    private static TripDto MapTrip(TripEntity trip)
+    {
+        return new TripDto(
+            trip.Id.Value,
+            trip.Destination,
+            trip.StartDate,
+            trip.EndDate);
+    }
+}

--- a/src/Trip.API/Application/Trips/CreateTrip/CreateTripResult.cs
+++ b/src/Trip.API/Application/Trips/CreateTrip/CreateTripResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Trips.CreateTrip;
+
+public sealed record CreateTripResult(TripDto Trip);

--- a/src/Trip.API/Application/Trips/GetTripById/GetTripByIdHandler.cs
+++ b/src/Trip.API/Application/Trips/GetTripById/GetTripByIdHandler.cs
@@ -1,0 +1,43 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Application.Trips.GetTripById;
+
+public sealed class GetTripByIdHandler
+{
+    private readonly ILogger<GetTripByIdHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public GetTripByIdHandler(ITripRepository tripRepository, ILogger<GetTripByIdHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<GetTripByIdResult> HandleAsync(GetTripByIdQuery query, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Retrieving trip {TripId} for user {UserId}",
+            query.TripId.Value,
+            query.UserId.Value);
+
+        var trip = await _tripRepository.GetByIdAsync(query.TripId, cancellationToken).ConfigureAwait(false);
+
+        if (trip is null)
+        {
+            throw new NotFoundException($"Trip {query.TripId.Value} was not found.");
+        }
+
+        if (trip.OwnerId != query.UserId)
+        {
+            throw new ForbiddenException($"Trip {query.TripId.Value} is not accessible for the current user.");
+        }
+
+        return new GetTripByIdResult(new TripDto(
+            trip.Id.Value,
+            trip.Destination,
+            trip.StartDate,
+            trip.EndDate));
+    }
+}

--- a/src/Trip.API/Application/Trips/GetTripById/GetTripByIdQuery.cs
+++ b/src/Trip.API/Application/Trips/GetTripById/GetTripByIdQuery.cs
@@ -1,0 +1,5 @@
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Trips.GetTripById;
+
+public sealed record GetTripByIdQuery(UserId UserId, TripId TripId);

--- a/src/Trip.API/Application/Trips/GetTripById/GetTripByIdResult.cs
+++ b/src/Trip.API/Application/Trips/GetTripById/GetTripByIdResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Trips.GetTripById;
+
+public sealed record GetTripByIdResult(TripDto Trip);

--- a/src/Trip.API/Application/Trips/GetTrips/GetTripsHandler.cs
+++ b/src/Trip.API/Application/Trips/GetTrips/GetTripsHandler.cs
@@ -1,0 +1,35 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Trips.GetTrips;
+
+public sealed class GetTripsHandler
+{
+    private readonly ILogger<GetTripsHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public GetTripsHandler(ITripRepository tripRepository, ILogger<GetTripsHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<GetTripsResult> HandleAsync(GetTripsQuery query, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Retrieving trips for user {UserId}", query.UserId.Value);
+
+        var trips = await _tripRepository
+            .GetByOwnerIdAsync(query.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var tripDtos = trips
+            .Select(trip => new TripDto(
+                trip.Id.Value,
+                trip.Destination,
+                trip.StartDate,
+                trip.EndDate))
+            .ToArray();
+
+        return new GetTripsResult(tripDtos);
+    }
+}

--- a/src/Trip.API/Application/Trips/GetTrips/GetTripsQuery.cs
+++ b/src/Trip.API/Application/Trips/GetTrips/GetTripsQuery.cs
@@ -1,0 +1,5 @@
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Trips.GetTrips;
+
+public sealed record GetTripsQuery(UserId UserId);

--- a/src/Trip.API/Application/Trips/GetTrips/GetTripsResult.cs
+++ b/src/Trip.API/Application/Trips/GetTrips/GetTripsResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Trips.GetTrips;
+
+public sealed record GetTripsResult(IReadOnlyList<TripDto> Trips);

--- a/src/Trip.API/Domain/Entities/Baggage.cs
+++ b/src/Trip.API/Domain/Entities/Baggage.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Trip.API.Domain.ValueObjects;
 using Trip.API.SeedWork;
-namespace Trip.API.Domain.Trips;
+namespace Trip.API.Domain.Entities;
 
 public sealed class Baggage : IEntity
 {
@@ -14,8 +14,8 @@ public sealed class Baggage : IEntity
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         TripId = tripId ?? throw new ArgumentNullException(nameof(tripId));
-        Name = !string.IsNullOrWhiteSpace(name) 
-            ? name 
+        Name = !string.IsNullOrWhiteSpace(name)
+            ? name
             : throw new ArgumentException("Baggage name cannot be null or empty.", nameof(name));
 
         IsDefaultBaggage = isDefaultBaggage;

--- a/src/Trip.API/Domain/Entities/Item.cs
+++ b/src/Trip.API/Domain/Entities/Item.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Trip.API.Domain.ValueObjects;
 using Trip.API.SeedWork;
-namespace Trip.API.Domain.Trips;
+namespace Trip.API.Domain.Entities;
 
 public sealed class Item : IEntity
 {
@@ -12,10 +12,10 @@ public sealed class Item : IEntity
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         BaggageId = baggageId ?? throw new ArgumentNullException(nameof(baggageId));
-        Name = !string.IsNullOrWhiteSpace(name) 
-            ? name 
+        Name = !string.IsNullOrWhiteSpace(name)
+            ? name
             : throw new ArgumentException("Item name cannot be null or empty.", nameof(name));
-        
+
         DefaultItemId = defaultItemId;
         CheckCount = 0;
     }

--- a/src/Trip.API/Domain/Entities/Trip.cs
+++ b/src/Trip.API/Domain/Entities/Trip.cs
@@ -1,21 +1,26 @@
 using System.Diagnostics.CodeAnalysis;
 using Trip.API.Domain.ValueObjects;
 using Trip.API.SeedWork;
-namespace Trip.API.Domain.Trips;
-    
+
+namespace Trip.API.Domain.Entities;
+
 public sealed class Trip : IEntity
 {
     private readonly List<Baggage> _baggages = new();
 
-    private Trip() { }
+    private Trip()
+    {
+    }
 
     [SetsRequiredMembers]
-    public Trip(TripId id, UserId ownerId, string? destination, DateOnly? startDate, DateOnly? endDate)
+    public Trip(TripId id, UserId ownerId, string destination, DateOnly? startDate, DateOnly? endDate)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
         OwnerId = ownerId ?? throw new ArgumentNullException(nameof(ownerId));
-        
-        Destination = destination;
+
+        Destination = !string.IsNullOrWhiteSpace(destination)
+            ? destination.Trim()
+            : throw new ArgumentException("Trip destination cannot be null or empty.", nameof(destination));
         StartDate = startDate;
         EndDate = endDate;
 
@@ -24,7 +29,7 @@ public sealed class Trip : IEntity
 
     public required TripId Id { get; init; }
     public required UserId OwnerId { get; init; }
-    public string? Destination { get; private set; }
+    public string Destination { get; private set; } = string.Empty;
     public DateOnly? StartDate { get; private set; }
     public DateOnly? EndDate { get; private set; }
 

--- a/src/Trip.API/Domain/Value-objects/Ids/TripId.cs
+++ b/src/Trip.API/Domain/Value-objects/Ids/TripId.cs
@@ -1,4 +1,5 @@
 namespace Trip.API.Domain.ValueObjects;
+
 public sealed record TripId(Guid Value)
 {
     public static TripId CreateUnique() => new(Guid.NewGuid());

--- a/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs
+++ b/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Trip.API.Infrastructure.Persistence.Configurations;
+
+public sealed class TripConfiguration : IEntityTypeConfiguration<TripDataModel>
+{
+    public void Configure(EntityTypeBuilder<TripDataModel> builder)
+    {
+        builder.HasKey(trip => trip.Id);
+
+        builder.Property(trip => trip.Destination)
+            .IsRequired();
+    }
+}

--- a/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs
+++ b/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs
@@ -1,0 +1,14 @@
+namespace Trip.API.Infrastructure.Persistence;
+
+public sealed class TripDataModel
+{
+    public Guid Id { get; set; }
+
+    public Guid OwnerId { get; set; }
+
+    public string Destination { get; set; } = string.Empty;
+
+    public DateOnly? StartDate { get; set; }
+
+    public DateOnly? EndDate { get; set; }
+}

--- a/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs
+++ b/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Trip.API.Infrastructure.Persistence;
+
+public sealed class TripDbContext : DbContext
+{
+    public TripDbContext(DbContextOptions<TripDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<TripDataModel> Trips => Set<TripDataModel>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(TripDbContext).Assembly);
+    }
+}

--- a/src/Trip.API/Infrastructure/Repositories/TripRepository.cs
+++ b/src/Trip.API/Infrastructure/Repositories/TripRepository.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Trip.API.Application.Abstractions;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.Infrastructure.Persistence;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.Infrastructure.Repositories;
+
+public sealed class TripRepository : ITripRepository
+{
+    private readonly TripDbContext _dbContext;
+
+    public TripRepository(TripDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(TripEntity trip, CancellationToken cancellationToken)
+    {
+        await _dbContext.Trips.AddAsync(
+            new TripDataModel
+            {
+                Id = trip.Id.Value,
+                OwnerId = trip.OwnerId.Value,
+                Destination = trip.Destination,
+                StartDate = trip.StartDate,
+                EndDate = trip.EndDate
+            },
+            cancellationToken).ConfigureAwait(false);
+
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+    {
+        var trips = await _dbContext.Trips
+            .AsNoTracking()
+            .Where(trip => trip.OwnerId == ownerId.Value)
+            .OrderBy(trip => trip.StartDate)
+            .ThenBy(trip => trip.Destination)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return trips.Select(MapTrip).ToArray();
+    }
+
+    public async Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .AsNoTracking()
+            .SingleOrDefaultAsync(trip => trip.Id == tripId.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        return trip is null ? null : MapTrip(trip);
+    }
+
+    private static TripEntity MapTrip(TripDataModel trip)
+    {
+        return new TripEntity(
+            TripId.FromGuid(trip.Id),
+            UserId.FromGuid(trip.OwnerId),
+            trip.Destination,
+            trip.StartDate,
+            trip.EndDate);
+    }
+}

--- a/src/Trip.API/Infrastructure/UserContext/HttpUserContextAccessor.cs
+++ b/src/Trip.API/Infrastructure/UserContext/HttpUserContextAccessor.cs
@@ -1,0 +1,35 @@
+using System.Security.Claims;
+using Trip.API.Application.Abstractions;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Infrastructure.UserContext;
+
+public sealed class HttpUserContextAccessor : IUserContextAccessor
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public HttpUserContextAccessor(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public UserId? GetCurrentUserId()
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+        if (httpContext is null)
+        {
+            return null;
+        }
+
+        if (httpContext.Request.Headers.TryGetValue(UserContextHeaderNames.TestUserId, out var values)
+            && Guid.TryParse(values.SingleOrDefault(), out var testUserId))
+        {
+            return UserId.FromGuid(testUserId);
+        }
+
+        var claimValue = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return Guid.TryParse(claimValue, out var claimUserId)
+            ? UserId.FromGuid(claimUserId)
+            : null;
+    }
+}

--- a/src/Trip.API/Infrastructure/UserContext/UserContextHeaderNames.cs
+++ b/src/Trip.API/Infrastructure/UserContext/UserContextHeaderNames.cs
@@ -1,0 +1,6 @@
+namespace Trip.API.Infrastructure.UserContext;
+
+public static class UserContextHeaderNames
+{
+    public const string TestUserId = "X-Test-User-Id";
+}

--- a/src/Trip.API/Program.cs
+++ b/src/Trip.API/Program.cs
@@ -1,43 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using Trip.API.Api.ErrorHandling;
+using Trip.API.Api.Trips;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Trips.CreateTrip;
+using Trip.API.Application.Trips.GetTripById;
+using Trip.API.Application.Trips.GetTrips;
+using Trip.API.Infrastructure.Persistence;
+using Trip.API.Infrastructure.Repositories;
+using Trip.API.Infrastructure.UserContext;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddProblemDetails();
+builder.Services.AddExceptionHandler<GlobalExceptionHandler>();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddDbContext<TripDbContext>(options =>
+    options.UseInMemoryDatabase("maletapp-trips"));
+
+builder.Services.AddScoped<ITripRepository, TripRepository>();
+builder.Services.AddScoped<IUserContextAccessor, HttpUserContextAccessor>();
+builder.Services.AddScoped<CreateTripHandler>();
+builder.Services.AddScoped<GetTripsHandler>();
+builder.Services.AddScoped<GetTripByIdHandler>();
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
 }
 
+app.UseExceptionHandler();
 app.UseHttpsRedirection();
 
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast");
+app.MapTripEndpoints();
 
 app.Run();
 
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}
+public partial class Program;

--- a/src/Trip.API/SeedkWork/IEntity.cs
+++ b/src/Trip.API/SeedkWork/IEntity.cs
@@ -1,3 +1,5 @@
 namespace Trip.API.SeedWork;
 
-public interface IEntity{}
+public interface IEntity
+{
+}

--- a/src/Trip.API/Trip.API.csproj
+++ b/src/Trip.API/Trip.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
   </ItemGroup>

--- a/src/Trip.API/appsettings.Development.json
+++ b/src/Trip.API/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "UserContext": {
+    "TestUserIdHeader": "X-Test-User-Id"
   }
 }

--- a/tests/Trip.API.IntegrationTests/GlobalUsings.cs
+++ b/tests/Trip.API.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs
+++ b/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs
@@ -1,0 +1,6 @@
+namespace Trip.API.IntegrationTests.Infrastructure;
+
+public static class TestUserContextHeaderNames
+{
+    public const string UserId = "X-Test-User-Id";
+}

--- a/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs
+++ b/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Trip.API.Infrastructure.Persistence;
+
+namespace Trip.API.IntegrationTests.Infrastructure;
+
+public sealed class TripApiFactory : WebApplicationFactory<Program>
+{
+    private readonly string _databaseName = $"maletapp-trips-tests-{Guid.NewGuid()}";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<DbContextOptions<TripDbContext>>();
+            services.RemoveAll<TripDbContext>();
+
+            services.AddDbContext<TripDbContext>(options =>
+                options.UseInMemoryDatabase(_databaseName));
+        });
+    }
+
+    public HttpClient CreateApiClient()
+    {
+        return CreateClient(new WebApplicationFactoryClientOptions
+        {
+            BaseAddress = new Uri("https://localhost")
+        });
+    }
+}

--- a/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj
+++ b/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Trip.API\Trip.API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Trip.API.IntegrationTests/Trips/CreateTripEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Trips/CreateTripEndpointTests.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Trips;
+
+public sealed class CreateTripEndpointTests
+{
+    [Fact]
+    public async Task PostTrips_ReturnsCreatedTrip_WhenRequestIsValid()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.PostAsJsonAsync("/trips", new
+        {
+            destination = "Bilbao",
+            startDate = new DateOnly(2026, 7, 10),
+            endDate = new DateOnly(2026, 7, 20)
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+        var trip = await response.Content.ReadFromJsonAsync<TripResponseContract>();
+        Assert.NotNull(trip);
+        Assert.Equal("Bilbao", trip.Destination);
+        Assert.NotEqual(Guid.Empty, trip.Id);
+    }
+
+    [Fact]
+    public async Task PostTrips_ReturnsBadRequest_WhenDestinationIsMissing()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.PostAsJsonAsync("/trips", new
+        {
+            destination = "",
+            startDate = (DateOnly?)null,
+            endDate = (DateOnly?)null
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostTrips_ReturnsUnauthorized_WhenUserHeaderIsMissing()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.PostAsJsonAsync("/trips", new
+        {
+            destination = "Dublin"
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+}

--- a/tests/Trip.API.IntegrationTests/Trips/GetTripByIdEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Trips/GetTripByIdEndpointTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Trips;
+
+public sealed class GetTripByIdEndpointTests
+{
+    [Fact]
+    public async Task GetTripById_ReturnsTrip_WhenOwnedByCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var createResponse = await client.PostAsJsonAsync("/trips", new { destination = "Vienna" });
+        var createdTrip = await createResponse.Content.ReadFromJsonAsync<TripResponseContract>();
+
+        var response = await client.GetAsync($"/trips/{createdTrip!.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTripById_ReturnsForbidden_WhenTripBelongsToDifferentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var createResponse = await ownerClient.PostAsJsonAsync("/trips", new { destination = "Athens" });
+        var createdTrip = await createResponse.Content.ReadFromJsonAsync<TripResponseContract>();
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await otherClient.GetAsync($"/trips/{createdTrip!.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTripById_ReturnsNotFound_WhenTripDoesNotExist()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.GetAsync($"/trips/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetTripById_ReturnsUnauthorized_WhenCurrentUserIsMissing()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var createResponse = await ownerClient.PostAsJsonAsync("/trips", new { destination = "Warsaw" });
+        var createdTrip = await createResponse.Content.ReadFromJsonAsync<TripResponseContract>();
+
+        using var anonymousClient = factory.CreateApiClient();
+        var response = await anonymousClient.GetAsync($"/trips/{createdTrip!.Id}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+}

--- a/tests/Trip.API.IntegrationTests/Trips/GetTripsEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Trips/GetTripsEndpointTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Trips;
+
+public sealed class GetTripsEndpointTests
+{
+    [Fact]
+    public async Task GetTrips_ReturnsOnlyTripsForCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        var currentUserId = Guid.NewGuid();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, currentUserId.ToString());
+
+        await client.PostAsJsonAsync("/trips", new { destination = "London" });
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        await otherClient.PostAsJsonAsync("/trips", new { destination = "Prague" });
+
+        var response = await client.GetAsync("/trips");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var trips = await response.Content.ReadFromJsonAsync<TripResponseContract[]>();
+        Assert.NotNull(trips);
+        var trip = Assert.Single(trips);
+        Assert.Equal("London", trip.Destination);
+    }
+
+    [Fact]
+    public async Task GetTrips_ReturnsEmptyArray_WhenCurrentUserHasNoTrips()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.GetAsync("/trips");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var trips = await response.Content.ReadFromJsonAsync<TripResponseContract[]>();
+        Assert.NotNull(trips);
+        Assert.Empty(trips);
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+}

--- a/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs
@@ -1,0 +1,76 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Trips.CreateTrip;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Trips;
+
+public sealed class CreateTripHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_CreatesTrip_WhenCommandIsValid()
+    {
+        var repository = new InMemoryTripRepository();
+        var handler = new CreateTripHandler(repository, NullLogger<CreateTripHandler>.Instance);
+        var userId = TripFixtures.CreateUserId();
+
+        var result = await handler.HandleAsync(
+            new CreateTripCommand(
+                userId,
+                TripFixtures.CreateNewTripDto("Berlin", new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 4))),
+            CancellationToken.None);
+
+        Assert.Equal("Berlin", result.Trip.Destination);
+        Assert.Single(repository.Trips);
+        Assert.Equal(userId, repository.Trips[0].OwnerId);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsValidationException_WhenDestinationIsMissing()
+    {
+        var repository = new InMemoryTripRepository();
+        var handler = new CreateTripHandler(repository, NullLogger<CreateTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<ValidationException>(() => handler.HandleAsync(
+            new CreateTripCommand(TripFixtures.CreateUserId(), TripFixtures.CreateNewTripDto(" ")),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsValidationException_WhenDatesAreInvalid()
+    {
+        var repository = new InMemoryTripRepository();
+        var handler = new CreateTripHandler(repository, NullLogger<CreateTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<ValidationException>(() => handler.HandleAsync(
+            new CreateTripCommand(
+                TripFixtures.CreateUserId(),
+                TripFixtures.CreateNewTripDto("Rome", new DateOnly(2026, 6, 10), new DateOnly(2026, 6, 1))),
+            CancellationToken.None));
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        public List<TripEntity> Trips { get; } = new();
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            Trips.Add(trip);
+            return Task.CompletedTask;
+        }
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Trips.SingleOrDefault(trip => trip.Id == tripId));
+        }
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<TripEntity>>(Trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+        }
+    }
+}

--- a/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Trips.GetTripById;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Trips;
+
+public sealed class GetTripByIdHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_ReturnsTrip_WhenOwnedByCurrentUser()
+    {
+        var userId = TripFixtures.CreateUserId();
+        var trip = TripFixtures.CreateTrip(userId, "Valencia");
+        var handler = new GetTripByIdHandler(
+            new InMemoryTripRepository(trip),
+            NullLogger<GetTripByIdHandler>.Instance);
+
+        var result = await handler.HandleAsync(new GetTripByIdQuery(userId, trip.Id), CancellationToken.None);
+
+        Assert.Equal(trip.Id.Value, result.Trip.Id);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsNotFoundException_WhenTripDoesNotExist()
+    {
+        var handler = new GetTripByIdHandler(
+            new InMemoryTripRepository(),
+            NullLogger<GetTripByIdHandler>.Instance);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => handler.HandleAsync(
+            new GetTripByIdQuery(TripFixtures.CreateUserId(), TripId.CreateUnique()),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsForbiddenException_WhenTripBelongsToDifferentUser()
+    {
+        var trip = TripFixtures.CreateTrip(TripFixtures.CreateUserId(), "Oslo");
+        var handler = new GetTripByIdHandler(
+            new InMemoryTripRepository(trip),
+            NullLogger<GetTripByIdHandler>.Instance);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => handler.HandleAsync(
+            new GetTripByIdQuery(TripFixtures.CreateUserId(), trip.Id),
+            CancellationToken.None));
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        private readonly IReadOnlyList<TripEntity> _trips;
+
+        public InMemoryTripRepository(params TripEntity[] trips)
+        {
+            _trips = trips;
+        }
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
+        }
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+        }
+    }
+}

--- a/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Trips.GetTrips;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Trips;
+
+public sealed class GetTripsHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_ReturnsOnlyTripsForRequestedUser()
+    {
+        var userId = TripFixtures.CreateUserId();
+        var repository = new InMemoryTripRepository(
+            TripFixtures.CreateTrip(userId, "Seville"),
+            TripFixtures.CreateTrip(TripFixtures.CreateUserId(), "Paris"));
+        var handler = new GetTripsHandler(repository, NullLogger<GetTripsHandler>.Instance);
+
+        var result = await handler.HandleAsync(new GetTripsQuery(userId), CancellationToken.None);
+
+        var trip = Assert.Single(result.Trips);
+        Assert.Equal("Seville", trip.Destination);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ReturnsEmptyCollection_WhenUserHasNoTrips()
+    {
+        var handler = new GetTripsHandler(new InMemoryTripRepository(), NullLogger<GetTripsHandler>.Instance);
+
+        var result = await handler.HandleAsync(new GetTripsQuery(TripFixtures.CreateUserId()), CancellationToken.None);
+
+        Assert.Empty(result.Trips);
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        private readonly IReadOnlyList<TripEntity> _trips;
+
+        public InMemoryTripRepository(params TripEntity[] trips)
+        {
+            _trips = trips;
+        }
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
+        }
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+        }
+    }
+}

--- a/tests/Trip.API.UnitTests/Domain/TripTests.cs
+++ b/tests/Trip.API.UnitTests/Domain/TripTests.cs
@@ -1,0 +1,49 @@
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Domain;
+
+public sealed class TripTests
+{
+    [Fact]
+    public void Constructor_CreatesTrip_WhenDestinationAndDatesAreValid()
+    {
+        var trip = new TripEntity(
+            TripId.CreateUnique(),
+            UserId.CreateUnique(),
+            "Lisbon",
+            new DateOnly(2026, 4, 1),
+            new DateOnly(2026, 4, 10));
+
+        Assert.Equal("Lisbon", trip.Destination);
+        Assert.Equal(new DateOnly(2026, 4, 1), trip.StartDate);
+        Assert.Equal(new DateOnly(2026, 4, 10), trip.EndDate);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsArgumentException_WhenDestinationIsMissing()
+    {
+        var action = () => new TripEntity(
+            TripId.CreateUnique(),
+            UserId.CreateUnique(),
+            " ",
+            null,
+            null);
+
+        Assert.Throws<ArgumentException>(action);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsInvalidOperationException_WhenStartDateIsAfterEndDate()
+    {
+        var action = () => new TripEntity(
+            TripId.CreateUnique(),
+            UserId.CreateUnique(),
+            "Tokyo",
+            new DateOnly(2026, 5, 10),
+            new DateOnly(2026, 5, 1));
+
+        Assert.Throws<InvalidOperationException>(action);
+    }
+}

--- a/tests/Trip.API.UnitTests/GlobalUsings.cs
+++ b/tests/Trip.API.UnitTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Trip.API.UnitTests/Testing/TripFixtures.cs
+++ b/tests/Trip.API.UnitTests/Testing/TripFixtures.cs
@@ -1,0 +1,36 @@
+using Trip.API.Application.Dtos;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Testing;
+
+public static class TripFixtures
+{
+    public static UserId CreateUserId()
+    {
+        return UserId.CreateUnique();
+    }
+
+    public static NewTripDto CreateNewTripDto(
+        string destination = "Madrid",
+        DateOnly? startDate = null,
+        DateOnly? endDate = null)
+    {
+        return new NewTripDto(destination, startDate, endDate);
+    }
+
+    public static TripEntity CreateTrip(
+        UserId? ownerId = null,
+        string destination = "Madrid",
+        DateOnly? startDate = null,
+        DateOnly? endDate = null)
+    {
+        return new TripEntity(
+            TripId.CreateUnique(),
+            ownerId ?? CreateUserId(),
+            destination,
+            startDate,
+            endDate);
+    }
+}

--- a/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj
+++ b/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Trip.API\Trip.API.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

  This PR introduces the first Trips API slice for Maletapp. It adds support for:

  - Creating a trip
  - Listing the current user's trips
  - Retrieving a trip by id

  The implementation follows the current feature plan and contract-first approach using:

  - ASP.NET Core Minimal API
  - Repository abstractions
  - Entity Framework Core with an in-memory provider
  - Current-user resolution via IUserContextAccessor
  - Structured problem-details error handling
  - Structured logging
  - End-to-end CancellationToken propagation

  ## What Changed

  ### API and Application

  - Replaced the starter weatherforecast endpoint with trip endpoints:
      - POST /trips
      - GET /trips
      - GET /trips/{tripId}
  - Added exact OpenAPI-aligned endpoint names:
      - createTrip
      - getTrips
      - getTripById
  - Added request/response models and application handlers for:
      - create trip
      - list trips
      - get trip detail
  - Added typed application exceptions for:
      - validation
      - unauthorized
      - forbidden
      - not found

  ### Domain and Infrastructure

  - Aligned the Trip domain entity with the feature requirements:
      - required destination
      - optional dates
      - invalid date-range protection
  - Added repository abstraction and EF Core-backed repository implementation
  - Added in-memory EF Core persistence for the current phase
  - Added HTTP-based user-context accessor using a test header fallback

  ### Error Handling and Observability

  - Added global exception handling with problem details responses
  - Added structured logging for trip operations and failures
  - Added explicit CancellationToken flow from endpoints through handlers and repositories

  ### Tests

  - Added unit tests for:
      - trip validation rules
      - create trip handler
      - list trips handler
      - get trip by id handler
  - Added integration tests for:
      - create trip endpoint
      - list trips endpoint
      - get trip by id endpoint
  - Added shared integration test factory and test helpers

  ### Planning and Tasking

  - Updated the implementation task file to reflect completed work
  - Updated repo guidance to require smaller commits and pushing after completed tasks

  ## Verification

  Passed locally:

  dotnet build --no-incremental
  dotnet test --no-build
  dotnet format --verify-no-changes

  ## Notes

  - Persistence is intentionally in-memory only for this phase
  - Authentication flow is still out of scope; current-user resolution is abstracted behind IUserContextAccessor
  - Items and Trips remain isolated per the constitution