### PR TITLE
002 trip items api

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -6,7 +6,7 @@
 All externally visible behavior for Items and Trips starts from the domain contract files in `spec/item.yml` and `spec/trip.yml` and their corresponding feature specifications and plans. Implementation must match the contract, and contract changes must be documented in the related specification work in the same session.
 
 ### II. Domain Separation
-Items and Trips are separate sub-APIs. Cross-domain dependencies, shared persistence models, or endpoint behavior that couples the domains are not allowed unless this constitution is amended first.
+Items and Trips are separate sub-APIs at the contract and endpoint surface. For the current single-service architecture, trip-owned baggages and items may share the same domain aggregate and persistence model when the relationship is strictly containment and ownership-based. Cross-domain behavior beyond that ownership boundary, including independent workflows that couple item behavior to unrelated trip concerns, is not allowed unless this constitution is amended first.
 
 ### III. Repository and Persistence Discipline
 Application code must depend on repository abstractions rather than direct persistence calls. Persistence implementations must use Entity Framework, with an in-memory provider acceptable for the current stage until a persistent store is intentionally introduced. Domain behavior remains isolated from infrastructure concerns.
@@ -36,4 +36,4 @@ Minimal API endpoints must propagate cancellation, return structured problem det
 
 This constitution supersedes conflicting local habits for this repository. Amendments must be reflected in this file before implementation relies on them. Every plan and review must explicitly check compliance with these principles and document any justified exception.
 
-**Version**: 1.0.0 | **Ratified**: 2026-03-14 | **Last Amended**: 2026-03-14
+**Version**: 1.1.0 | **Ratified**: 2026-03-14 | **Last Amended**: 2026-03-15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@
 ## Active Technologies
 - C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling (001-add-trip-api)
 - Entity Framework in-memory database for the current phase (001-add-trip-api)
+- Entity Framework in-memory database for the current phase, expanded to persist trips with related baggages and items (002-trip-items-api)
 
 ## Recent Changes
 - 001-add-trip-api: Added C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling

--- a/specs/002-trip-items-api/checklists/requirements.md
+++ b/specs/002-trip-items-api/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Trip Item Access
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-15
+**Feature**: [spec.md](/home/sicor/local-repos/maletapp/specs/002-trip-items-api/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1: all checklist items passed.
+- The request referenced `spec/item.yml` as the contract source; this spec stays aligned to that contract's item concepts while describing the feature in user-facing terms.

--- a/specs/002-trip-items-api/contracts/items.md
+++ b/specs/002-trip-items-api/contracts/items.md
@@ -1,0 +1,82 @@
+# Items API Contract Summary
+
+Source of truth: [item.yml](/home/sicor/local-repos/maletapp/spec/item.yml)
+
+## Endpoints
+
+### `GET /trips/{tripId}/items` (`listItemsByTrip`)
+
+- Purpose: Retrieve all items associated with one trip owned by the current user.
+- Path parameter:
+  - `tripId`: required UUID string
+- Success response:
+  - `200 OK`
+  - Response body is an array of item objects
+- Failure outcomes:
+  - `401 Unauthorized` when no current user can be resolved
+  - `403 Forbidden` when the trip belongs to a different user
+  - `404 Not Found` when the trip does not exist
+  - `500 Internal Server Error` for unexpected failures
+
+### `POST /trips/{tripId}/items` (`createItemInTrip`)
+
+- Purpose: Create a new item directly under a trip owned by the current user.
+- Path parameter:
+  - `tripId`: required UUID string
+- Request body:
+  - `name`: required string
+  - `defaultItemId`: optional UUID string
+- Success response:
+  - `201 Created`
+  - Response body contains item `id`, `tripId`, `baggageId`, `name`, `checkCount`, and optional `defaultItemId`
+- Failure outcomes:
+  - `400 Bad Request` for invalid input
+  - `401 Unauthorized` when no current user can be resolved
+  - `403 Forbidden` when the trip belongs to a different user
+  - `404 Not Found` when the trip does not exist
+  - `500 Internal Server Error` for unexpected failures
+
+### `GET /items/{itemId}` (`getItem`)
+
+- Purpose: Retrieve a single item by identifier when its trip is owned by the current user.
+- Path parameter:
+  - `itemId`: required UUID string
+- Success response:
+  - `200 OK`
+  - Response body contains item `id`, `tripId`, `baggageId`, `name`, `checkCount`, and optional `defaultItemId`
+- Failure outcomes:
+  - `401 Unauthorized` when no current user can be resolved
+  - `403 Forbidden` when the related trip belongs to a different user
+  - `404 Not Found` when the item does not exist
+  - `500 Internal Server Error` for unexpected failures
+
+### `PATCH /items/{itemId}` (`patchItem`)
+
+- Purpose: Partially update a single owned item by identifier.
+- Path parameter:
+  - `itemId`: required UUID string
+- Request body:
+  - `name`: optional string
+  - `defaultItemId`: optional UUID string
+- Success response:
+  - `200 OK`
+  - Response body contains the updated item object
+- Failure outcomes:
+  - `400 Bad Request` for invalid input
+  - `401 Unauthorized` when no current user can be resolved
+  - `403 Forbidden` when the related trip belongs to a different user
+  - `404 Not Found` when the item does not exist
+  - `500 Internal Server Error` for unexpected failures
+
+## Ownership Rules
+
+- Every supported item endpoint must resolve the current user before performing the requested operation.
+- Trip-scoped item list and create operations are allowed only when the requested trip belongs to the current user.
+- Single-item retrieve and patch operations are allowed only when the item's associated trip belongs to the current user.
+- Requests for another user's trip or item return `403 Forbidden`.
+
+## Response Shape Notes
+
+- `Item` responses include `id`, `tripId`, `baggageId`, `name`, `checkCount`, and optional `defaultItemId`.
+- `NewItem` requires `name` and allows an optional `defaultItemId`.
+- `PatchItem` supports partial changes and must not allow client control over `id`, `tripId`, `baggageId`, or `checkCount`.

--- a/specs/002-trip-items-api/data-model.md
+++ b/specs/002-trip-items-api/data-model.md
@@ -1,0 +1,104 @@
+# Data Model: Trip Item Access
+
+## Trip
+
+- Purpose: Represents a travel plan owned by a single user and serves as the ownership boundary for all item operations in this feature.
+- Fields:
+  - `Id`: Unique trip identifier.
+  - `OwnerId`: User identifier used for ownership checks.
+  - `Destination`: Required trip destination.
+  - `StartDate`: Optional trip start date.
+  - `EndDate`: Optional trip end date.
+- Relationships:
+  - One trip belongs to one user.
+  - One trip can contain many baggages.
+  - One trip can contain many items through its baggages.
+- Validation rules:
+  - `Destination` is required and cannot be blank.
+  - If both dates are present, `StartDate` must be on or before `EndDate`.
+- State transitions:
+  - Retrieved for item listing: Trip is loaded and ownership is verified before its items are returned.
+  - Used for item creation: Trip is loaded, ownership is verified, and the item is added to the trip's default baggage.
+
+## Baggage
+
+- Purpose: Groups items within a trip and provides the default assignment target for trip-level item creation.
+- Fields:
+  - `Id`: Unique baggage identifier.
+  - `TripId`: Identifier of the owning trip.
+  - `Name`: Baggage label.
+  - `IsDefaultBaggage`: Indicates whether the baggage is the default destination for direct trip item creation.
+- Relationships:
+  - One baggage belongs to one trip.
+  - One baggage can contain many items.
+- Validation rules:
+  - `Name` is required and cannot be blank.
+  - At most one baggage should act as the trip's default baggage in this feature design.
+- State transitions:
+  - Existing default baggage reused during direct item creation.
+  - Default baggage created on demand when a trip has no existing default baggage and the user creates an item directly under the trip.
+
+## Item
+
+- Purpose: Represents a packing-list entry that is owned indirectly through its trip association.
+- Fields:
+  - `Id`: Unique item identifier.
+  - `TripId`: Identifier of the owning trip exposed in responses.
+  - `BaggageId`: Identifier of the baggage containing the item.
+  - `Name`: Item name.
+  - `CheckCount`: Number of times the item has been marked as checked.
+  - `DefaultItemId`: Optional reference to a predefined item identifier.
+- Relationships:
+  - One item belongs to one baggage.
+  - One item belongs to one trip through its baggage.
+- Validation rules:
+  - `Name` is required on creation and cannot be blank on update.
+  - `CheckCount` is non-negative and read-only for this feature.
+  - `DefaultItemId`, when present, must be a UUID.
+- State transitions:
+  - Created: Item is added to the trip's default baggage with `CheckCount` starting at zero.
+  - Retrieved: Item is returned only if its trip belongs to the current user.
+  - Updated: Item name and other patchable contract fields may change without altering ownership or trip association.
+
+## Current User Context
+
+- Purpose: Represents the authenticated user identity available for the active request.
+- Fields:
+  - `UserId`: Unique identifier used to enforce trip ownership.
+- Relationships:
+  - One current-user context maps to zero or more owned trips.
+- Validation rules:
+  - A request without a determinable user identity is invalid for all four item endpoints in this feature.
+
+## Request and Response Shapes
+
+### New Item Input
+
+- Fields:
+  - `Name`: Required text value.
+  - `DefaultItemId`: Optional UUID reference.
+- Validation rules:
+  - Input must include a non-blank `Name`.
+  - `DefaultItemId`, when present, must be a UUID.
+
+### Patch Item Input
+
+- Fields:
+  - `Name`: Optional replacement item name.
+  - `DefaultItemId`: Optional replacement or clearing value for the predefined item reference.
+- Validation rules:
+  - If `Name` is provided, it cannot be blank.
+  - If `DefaultItemId` is provided, it must be a UUID or an explicit null-equivalent allowed by the contract implementation.
+
+### Item Output
+
+- Fields:
+  - `Id`
+  - `TripId`
+  - `BaggageId`
+  - `Name`
+  - `CheckCount`
+  - `DefaultItemId`
+- Notes:
+  - Ownership is enforced through the related trip and is not returned as a separate field.
+  - `Id`, `TripId`, `BaggageId`, and `CheckCount` are system-controlled values in this feature.

--- a/specs/002-trip-items-api/plan.md
+++ b/specs/002-trip-items-api/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Trip Item Access
+
+**Branch**: `002-trip-items-api` | **Date**: 2026-03-15 | **Spec**: [spec.md](/home/sicor/local-repos/maletapp/specs/002-trip-items-api/spec.md)
+**Input**: Feature specification from `/specs/002-trip-items-api/spec.md`
+
+## Summary
+
+Implement the Items API slice for listing all items in an owned trip, creating an item directly under an owned trip, retrieving a single owned item, and partially updating a single owned item. The implementation will extend the existing Minimal API and repository-based Trip API structure, preserve trip-based ownership checks through the current-user accessor, align endpoint names with the OpenAPI `operationId` values, persist trip, baggage, and item data through Entity Framework with the in-memory provider, and add both unit and integration coverage for item behaviors and access control.
+
+## Technical Context
+
+**Language/Version**: C# with .NET 10 (`net10.0`)  
+**Primary Dependencies**: ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling  
+**Storage**: Entity Framework in-memory database for the current phase, expanded to persist trips with related baggages and items  
+**Testing**: .NET test runner with unit tests for domain/application behavior and integration tests for HTTP endpoints, ownership rules, and persistence wiring  
+**Target Platform**: Linux-hosted ASP.NET Core web service  
+**Project Type**: Web service  
+**Performance Goals**: Support local development, automated test execution, and manual verification of item list, create, retrieve, and patch flows with no perceptible latency  
+**Constraints**: Preserve Items/Trips contract separation, use repository abstractions rather than direct persistence calls, enforce ownership before all supported item operations, propagate `CancellationToken` from endpoints through handlers and repositories, use structured logging and typed exceptions, keep public endpoint handler names equal to the OpenAPI `operationId` values, and keep warnings at zero  
+**Scale/Scope**: Initial Items API slice with 4 endpoints, 1 existing trip aggregate extended for baggages/items, request-scoped ownership checks, and no deletion or check-item behavior in this phase
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- `Contract-First Delivery`: Pass. The plan is derived from [spec.md](/home/sicor/local-repos/maletapp/specs/002-trip-items-api/spec.md) and remains aligned with [item.yml](/home/sicor/local-repos/maletapp/spec/item.yml).
+- `Domain Separation`: Pass. The implementation stays within the existing API boundary and does not introduce cross-sub-API behavior beyond trip ownership used to authorize item access.
+- `Repository and Persistence Discipline`: Pass. The design extends repository abstractions and Entity Framework persistence rather than using direct endpoint-to-database access.
+- `Testable by Default`: Pass. The plan includes unit tests for item domain and application rules plus integration tests for all 4 endpoints and failure paths.
+- `Operational Consistency`: Pass. The design keeps Minimal API handlers, explicit `CancellationToken` propagation, structured logging, typed failures, and problem-details-friendly exception handling.
+
+Post-design re-check: Pass. The generated research, data model, contracts, and quickstart artifacts preserve repository boundaries, contract-first behavior, endpoint naming rules, and dual-layer testing expectations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-trip-items-api/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── items.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── Trip.API/
+    ├── Domain/
+    │   ├── Entities/
+    │   └── Value-objects/
+    ├── Application/
+    │   ├── Abstractions/
+    │   ├── Dtos/
+    │   ├── Exceptions/
+    │   ├── Items/
+    │   └── Trips/
+    ├── Infrastructure/
+    │   ├── Persistence/
+    │   │   └── Configurations/
+    │   ├── Repositories/
+    │   └── UserContext/
+    └── Api/
+        ├── ErrorHandling/
+        ├── Items/
+        └── Trips/
+
+tests/
+├── Trip.API.UnitTests/
+│   ├── Application/
+│   └── Domain/
+└── Trip.API.IntegrationTests/
+    ├── Infrastructure/
+    └── Items/
+```
+
+**Structure Decision**: Keep a single deployable API project and add item-specific application and endpoint folders inside `src/Trip.API`, while extending the existing domain and persistence layers for baggages and items. Keep separate unit and integration test projects under `tests/` so item rules, ownership behavior, and HTTP contract conformance can evolve independently.
+
+## Complexity Tracking
+
+No constitutional violations or justified exceptions are required for this plan.

--- a/specs/002-trip-items-api/plan.md
+++ b/specs/002-trip-items-api/plan.md
@@ -24,7 +24,7 @@ Implement the Items API slice for listing all items in an owned trip, creating a
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
 - `Contract-First Delivery`: Pass. The plan is derived from [spec.md](/home/sicor/local-repos/maletapp/specs/002-trip-items-api/spec.md) and remains aligned with [item.yml](/home/sicor/local-repos/maletapp/spec/item.yml).
-- `Domain Separation`: Pass. The implementation stays within the existing API boundary and does not introduce cross-sub-API behavior beyond trip ownership used to authorize item access.
+- `Domain Separation`: Pass. The implementation keeps Items and Trips separate at the contract surface while using the current trip-owned aggregate and persistence boundary for baggages and items, which is allowed by the amended constitution for this single-service phase.
 - `Repository and Persistence Discipline`: Pass. The design extends repository abstractions and Entity Framework persistence rather than using direct endpoint-to-database access.
 - `Testable by Default`: Pass. The plan includes unit tests for item domain and application rules plus integration tests for all 4 endpoints and failure paths.
 - `Operational Consistency`: Pass. The design keeps Minimal API handlers, explicit `CancellationToken` propagation, structured logging, typed failures, and problem-details-friendly exception handling.
@@ -79,7 +79,7 @@ tests/
     └── Items/
 ```
 
-**Structure Decision**: Keep a single deployable API project and add item-specific application and endpoint folders inside `src/Trip.API`, while extending the existing domain and persistence layers for baggages and items. Keep separate unit and integration test projects under `tests/` so item rules, ownership behavior, and HTTP contract conformance can evolve independently.
+**Structure Decision**: Keep a single deployable API project and add item-specific application and endpoint folders inside `src/Trip.API`, while extending the existing trip-owned domain and persistence layers for baggages and items. This preserves separate item contracts without introducing a premature split away from the current ownership aggregate. Keep separate unit and integration test projects under `tests/` so item rules, ownership behavior, and HTTP contract conformance can evolve independently.
 
 ## Complexity Tracking
 

--- a/specs/002-trip-items-api/plan.md
+++ b/specs/002-trip-items-api/plan.md
@@ -15,7 +15,7 @@ Implement the Items API slice for listing all items in an owned trip, creating a
 **Testing**: .NET test runner with unit tests for domain/application behavior and integration tests for HTTP endpoints, ownership rules, and persistence wiring  
 **Target Platform**: Linux-hosted ASP.NET Core web service  
 **Project Type**: Web service  
-**Performance Goals**: Support local development, automated test execution, and manual verification of item list, create, retrieve, and patch flows with no perceptible latency  
+**Performance Goals**: Support local development, automated test execution, and manual verification of item list, create, retrieve, and patch flows  
 **Constraints**: Preserve Items/Trips contract separation, use repository abstractions rather than direct persistence calls, enforce ownership before all supported item operations, propagate `CancellationToken` from endpoints through handlers and repositories, use structured logging and typed exceptions, keep public endpoint handler names equal to the OpenAPI `operationId` values, and keep warnings at zero  
 **Scale/Scope**: Initial Items API slice with 4 endpoints, 1 existing trip aggregate extended for baggages/items, request-scoped ownership checks, and no deletion or check-item behavior in this phase
 

--- a/specs/002-trip-items-api/quickstart.md
+++ b/specs/002-trip-items-api/quickstart.md
@@ -1,0 +1,36 @@
+# Quickstart: Trip Item Access
+
+## Goal
+
+Implement the item endpoints so the current user can list items for an owned trip, add an item directly to an owned trip, retrieve one owned item, and partially update one owned item while keeping authorization trip-based.
+
+## Implementation Sequence
+
+1. Extend the persistence model so trips can be stored and loaded with related baggages and items.
+2. Expand repository abstractions and implementations to support trip item listing, trip item creation, item lookup, and item patch flows without exposing persistence details to endpoints.
+3. Add or align item-focused application DTOs, commands, queries, results, and handlers under `src/Trip.API/Application/Items/`.
+4. Add request and response models for `listItemsByTrip`, `createItemInTrip`, `getItem`, and `patchItem` that match the item contract.
+5. Add item endpoint handlers under `src/Trip.API/Api/Items/` with names matching the OpenAPI `operationId` values.
+6. Resolve the current user at each item endpoint, enforce ownership before completing the operation, and return typed failure outcomes for unauthorized, forbidden, validation, and not-found cases.
+7. Reuse the trip domain's default-baggage behavior for direct trip item creation and preserve trip association during item updates.
+8. Add unit tests for item validation, default-baggage behavior, and application ownership rules.
+9. Add integration tests that exercise all four HTTP endpoints, including success cases and foreign-trip, missing-user, invalid-input, and missing-record failures.
+
+## Verification
+
+1. Run `dotnet build --no-incremental`.
+2. Run `dotnet test --no-build`.
+3. Run `dotnet format --verify-no-changes`.
+4. Manually verify Swagger or HTTP calls for:
+   - listing items for an owned trip
+   - creating an item under an owned trip without supplying a baggage identifier
+   - retrieving an owned item by id
+   - patching an owned item name or default item reference
+   - receiving `403 Forbidden` for another user's trip or item
+   - receiving clear failures for invalid UUIDs, missing user context, bad request bodies, and missing records
+
+## Notes
+
+- Keep the authentication mechanism out of scope and continue using the current-user accessor abstraction.
+- Keep the feature limited to the four item endpoints in the current spec.
+- Preserve the repository boundary even if extending EF Core mappings for nested baggages and items requires broader infrastructure changes.

--- a/specs/002-trip-items-api/research.md
+++ b/specs/002-trip-items-api/research.md
@@ -1,0 +1,37 @@
+# Research: Trip Item Access
+
+## Decision 1: Reuse the existing trip aggregate to create and authorize items
+
+- Decision: Keep item creation and ownership checks rooted in the existing `Trip` aggregate instead of introducing a separate ownership source.
+- Rationale: The current domain already models `Trip`, `Baggage`, and `Item`, and the feature requirement says authorization must be based on whether the related trip belongs to the authenticated user. Reusing that aggregate keeps authorization logic coherent and avoids cross-domain coupling.
+- Alternatives considered: A standalone item ownership store was rejected because it duplicates trip ownership and makes authorization harder to reason about. A baggage-first ownership model was rejected because the user-facing contract is trip-scoped for creation and listing.
+
+## Decision 2: Extend repository persistence to include baggages and items in the same API boundary
+
+- Decision: Expand the existing repository and persistence model so trips can be loaded and saved together with baggages and items needed for the four item endpoints.
+- Rationale: The current `TripRepository` and in-memory EF setup already anchor trip storage. Extending that shape preserves the constitution's repository rule and avoids bypassing the current persistence layer from handlers.
+- Alternatives considered: Direct `DbContext` access from item handlers was rejected because it would break repository discipline. Creating a second, unrelated item persistence path was rejected because the current domain entities already place items under trips and baggages.
+
+## Decision 3: Use the trip's default baggage behavior for direct trip item creation
+
+- Decision: Implement `POST /trips/{tripId}/items` by using the trip's default baggage behavior so the item is assigned automatically without a baggage selection step.
+- Rationale: The OpenAPI contract explicitly states that trip-level item creation assigns the item to a default baggage internally, and the current domain already contains `AddItemToDefaultBaggage` behavior that either uses or creates that default baggage.
+- Alternatives considered: Requiring the client to submit a baggage identifier was rejected because it would violate the contract. Failing all creates unless a default baggage already exists was rejected because the current domain model already supports creating the default baggage on demand.
+
+## Decision 4: Enforce ownership uniformly through current-user resolution plus typed failures
+
+- Decision: Resolve the current user at the endpoint boundary, pass it into item handlers, and return typed unauthorized, forbidden, validation, and not-found failures through the existing exception handling pipeline.
+- Rationale: The existing trip endpoints already follow this pattern, and the feature requires ownership checks on all four item endpoints, including item retrieval and patch. A uniform failure model keeps behavior predictable and testable.
+- Alternatives considered: Delaying ownership checks until after data mutation was rejected because the requirement says to verify ownership before performing operations. Returning ambiguous empty success responses was rejected because the spec calls for clear forbidden and not-found outcomes.
+
+## Decision 5: Keep endpoint names and route contracts aligned with the OpenAPI item specification
+
+- Decision: Name the public item endpoint handlers to match `listItemsByTrip`, `createItemInTrip`, `getItem`, and `patchItem`, and keep request and response payloads aligned with `NewItem`, `PatchItem`, and `Item`.
+- Rationale: The constitution requires endpoint names to match the OpenAPI `operationId` values exactly, and the user explicitly asked for schema compliance with the current item contract.
+- Alternatives considered: Reusing file or method names based on internal conventions alone was rejected because it would drift from the contract. Broadening the scope to baggage item endpoints or check-item behavior was rejected because this feature is explicitly limited to four item endpoints.
+
+## Decision 6: Cover the feature with both unit and integration tests
+
+- Decision: Add unit tests for item validation, default-baggage creation, and authorization-oriented application behavior, plus integration tests covering successful and failing HTTP flows for all four endpoints.
+- Rationale: The constitution requires both unit and integration tests. This feature has domain rules, application ownership checks, and externally visible API behavior that each need direct coverage.
+- Alternatives considered: Unit tests only were rejected because they would not verify route wiring, serialization, and problem responses. Integration tests only were rejected because they would make domain rule failures slower to isolate.

--- a/specs/002-trip-items-api/spec.md
+++ b/specs/002-trip-items-api/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Trip Item Access
+
+**Feature Branch**: `002-trip-items-api`  
+**Created**: 2026-03-15  
+**Status**: Draft  
+**Input**: User description: "Using the OpenAPI specification already present in the project (spec/item.yml), implement the Items feature for the travel API. Focus exclusively on the following endpoints: - GET /trips/{tripId}/items — List all items belonging to a specific trip - POST /trips/{tripId}/items — Create a new item under a trip (assigned internally to a default baggage) - GET /items/{itemId} — Retrieve a single item by its ID - PATCH /items/{itemId} — Rename or update an item by its ID Before performing any operation, verify that the trip associated with the item belongs to the authenticated user. If the trip does not belong to the current user, return 403 Forbidden. This check must be applied to all four endpoints. Same when you are going to retrieve or patch a single ITEM, check if this items is associated with the user. - Follow the request/response schemas defined in the OpenAPI spec (NewItem, Item, and related components) - All IDs are UUIDs - POST /trips/{tripId}/items must assign the created item to the"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - View items for my trip (Priority: P1)
+
+As a traveler, I want to see all items already assigned to one of my trips so I can review what I plan to carry.
+
+**Why this priority**: Listing trip items is the fastest way for a user to inspect packing progress and confirm the trip context before making changes.
+
+**Independent Test**: Can be fully tested by requesting the items for a trip owned by the current user and confirming the response contains only items linked to that trip.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user who owns a trip with multiple items, **When** the user requests that trip's items, **Then** the system returns all items associated with that trip.
+2. **Given** an authenticated user who owns a trip with no items, **When** the user requests that trip's items, **Then** the system returns an empty list.
+3. **Given** an authenticated user, **When** the user requests items for a trip owned by another user, **Then** the system denies access.
+
+---
+
+### User Story 2 - Add an item to my trip (Priority: P2)
+
+As a traveler, I want to add a new item directly to one of my trips so I can build my packing list without choosing a baggage manually.
+
+**Why this priority**: Creating items turns a trip into an actionable packing list and depends on a valid trip context already existing.
+
+**Independent Test**: Can be fully tested by creating an item under a trip owned by the current user and confirming the saved item is linked to that trip and assigned to the trip's default baggage.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user who owns a trip, **When** the user submits a valid new item for that trip, **Then** the system creates the item, associates it with the trip, and assigns it to that trip's default baggage.
+2. **Given** an authenticated user, **When** the user submits a new item for a trip owned by another user, **Then** the system denies access and does not create the item.
+3. **Given** an authenticated user who owns a trip, **When** the user submits an item without the required item name, **Then** the system rejects the request and explains the validation failure.
+
+---
+
+### User Story 3 - View or update a specific item I own (Priority: P3)
+
+As a traveler, I want to retrieve one item or change its details so I can confirm or correct my packing list one item at a time.
+
+**Why this priority**: Single-item lookup and editing are useful follow-up actions once items exist, but they are less foundational than listing and creating trip items.
+
+**Independent Test**: Can be fully tested by retrieving and updating an existing item owned by the current user and confirming the returned item reflects the expected values while ownership checks remain enforced.
+
+**Acceptance Scenarios**:
+
+1. **Given** an authenticated user and an existing item associated with one of that user's trips, **When** the user requests that item by identifier, **Then** the system returns the item details.
+2. **Given** an authenticated user and an existing item associated with one of that user's trips, **When** the user submits a valid partial update for that item, **Then** the system saves the new values and returns the updated item.
+3. **Given** an authenticated user, **When** the user requests or updates an item associated with another user's trip, **Then** the system denies access.
+4. **Given** an authenticated user, **When** the user requests or updates an item that does not exist, **Then** the system reports that the item was not found.
+
+### Edge Cases
+
+- A user supplies an identifier that is not a valid UUID for a trip or item request.
+- A trip exists but has no default baggage available when the user attempts to add an item directly to the trip.
+- A user submits a partial update that changes none of the item fields.
+- A user submits a partial update with an empty item name.
+- The system cannot determine the current authenticated user for the request.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow the current authenticated user to retrieve all items associated with a specific trip owned by that user.
+- **FR-002**: The system MUST return only items associated with the requested trip when listing a trip's items.
+- **FR-003**: The system MUST return an empty list when the current user requests a trip they own that has no items.
+- **FR-004**: The system MUST allow the current authenticated user to create a new item under a trip owned by that user using the item creation fields defined for this feature.
+- **FR-005**: The system MUST assign each newly created item a UUID.
+- **FR-006**: The system MUST associate each newly created item with the requested trip and with that trip's default baggage.
+- **FR-007**: The system MUST allow the current authenticated user to retrieve a single item by UUID when that item is associated with a trip owned by that user.
+- **FR-008**: The system MUST allow the current authenticated user to partially update a single item by UUID when that item is associated with a trip owned by that user.
+- **FR-009**: The system MUST limit item updates in this feature to the fields defined as updateable by the item contract for partial updates.
+- **FR-010**: The system MUST apply an ownership check before completing any of the four supported item operations and MUST deny access when the related trip is not owned by the current authenticated user.
+- **FR-011**: The system MUST return a forbidden outcome for list, create, retrieve, and update requests when the related trip belongs to a different user.
+- **FR-012**: The system MUST report when the requested trip or item does not exist.
+- **FR-013**: The system MUST reject item creation or update requests that do not satisfy the required item data rules, including a missing required item name on creation.
+- **FR-014**: The system MUST preserve the item data defined for this feature: item identifier, trip identifier, baggage identifier, item name, check count, and optional default item reference.
+- **FR-015**: The system MUST reject requests that do not have a determinable current authenticated user.
+- **FR-016**: All trip identifiers, item identifiers, baggage identifiers, and default item references used by this feature MUST be UUID values.
+
+### Key Entities *(include if feature involves data)*
+
+- **Item**: A packing-list entry owned indirectly through a trip, identified uniquely, linked to one trip and one baggage, with a name, a check count, and an optional reference to a predefined item.
+- **Trip**: A travel plan owned by one user that groups items and supplies the default baggage used when an item is created directly under the trip.
+- **Current User Context**: The request-scoped authenticated identity used to determine trip ownership and whether item access is allowed.
+
+### Assumptions
+
+- The feature scope is limited to listing trip items, creating an item directly under a trip, retrieving one item, and partially updating one item.
+- A valid authenticated user identity is expected to be available for each authorized request, but the authentication mechanism itself is outside this feature's scope.
+- Each trip has exactly one default baggage available for direct item creation; if that baggage cannot be resolved, item creation fails clearly rather than assigning the item elsewhere.
+- Item updates in this phase are limited to fields explicitly allowed by the existing item contract for partial updates.
+- No item deletion, item check action, baggage-specific item creation, item sharing, or cross-user collaboration behavior is included in this phase.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In validation testing, 100% of item list requests for a user's own trip return only items associated with that selected trip.
+- **SC-002**: A user can add a new item to one of their trips in a single submission without having to choose a baggage manually.
+- **SC-003**: In validation testing, 100% of successful single-item retrievals and updates return the correct item and preserve its trip association.
+- **SC-004**: In validation testing, 100% of requests involving another user's trip or item are denied with a forbidden outcome.
+- **SC-005**: In validation testing, 100% of requests with missing data, invalid UUIDs, unresolved ownership, or missing records return a clear failure outcome instead of an ambiguous success response.

--- a/specs/002-trip-items-api/spec.md
+++ b/specs/002-trip-items-api/spec.md
@@ -57,7 +57,7 @@ As a traveler, I want to retrieve one item or change its details so I can confir
 ### Edge Cases
 
 - A user supplies an identifier that is not a valid UUID for a trip or item request.
-- A trip exists but has no default baggage available when the user attempts to add an item directly to the trip.
+- A trip exists but has no default baggage yet when the user attempts to add an item directly to the trip.
 - A user submits a partial update that changes none of the item fields.
 - A user submits a partial update with an empty item name.
 - The system cannot determine the current authenticated user for the request.
@@ -72,9 +72,10 @@ As a traveler, I want to retrieve one item or change its details so I can confir
 - **FR-004**: The system MUST allow the current authenticated user to create a new item under a trip owned by that user using the item creation fields defined for this feature.
 - **FR-005**: The system MUST assign each newly created item a UUID.
 - **FR-006**: The system MUST associate each newly created item with the requested trip and with that trip's default baggage.
+- **FR-006a**: The system MUST create the trip's default baggage during direct trip item creation when no default baggage exists yet.
 - **FR-007**: The system MUST allow the current authenticated user to retrieve a single item by UUID when that item is associated with a trip owned by that user.
 - **FR-008**: The system MUST allow the current authenticated user to partially update a single item by UUID when that item is associated with a trip owned by that user.
-- **FR-009**: The system MUST limit item updates in this feature to the fields defined as updateable by the item contract for partial updates.
+- **FR-009**: The system MUST limit item updates in this feature to `name` and `defaultItemId` during partial updates.
 - **FR-010**: The system MUST apply an ownership check before completing any of the four supported item operations and MUST deny access when the related trip is not owned by the current authenticated user.
 - **FR-011**: The system MUST return a forbidden outcome for list, create, retrieve, and update requests when the related trip belongs to a different user.
 - **FR-012**: The system MUST report when the requested trip or item does not exist.
@@ -93,8 +94,8 @@ As a traveler, I want to retrieve one item or change its details so I can confir
 
 - The feature scope is limited to listing trip items, creating an item directly under a trip, retrieving one item, and partially updating one item.
 - A valid authenticated user identity is expected to be available for each authorized request, but the authentication mechanism itself is outside this feature's scope.
-- Each trip has exactly one default baggage available for direct item creation; if that baggage cannot be resolved, item creation fails clearly rather than assigning the item elsewhere.
-- Item updates in this phase are limited to fields explicitly allowed by the existing item contract for partial updates.
+- Direct trip item creation reuses the trip's default baggage when it already exists and creates that default baggage on demand when it does not yet exist.
+- Item updates in this phase are limited to `name` and `defaultItemId`.
 - No item deletion, item check action, baggage-specific item creation, item sharing, or cross-user collaboration behavior is included in this phase.
 
 ## Success Criteria *(mandatory)*

--- a/specs/002-trip-items-api/tasks.md
+++ b/specs/002-trip-items-api/tasks.md
@@ -47,20 +47,20 @@
 
 **Goal**: Return all items for one owned trip and deny access to foreign trips
 
-**Independent Test**: Seed multiple trips and items for different users, request `GET /trips/{tripId}/items`, and verify the response contains only the selected owned trip's items, returns an empty list for an owned empty trip, and returns forbidden for a foreign trip
+**Independent Test**: Seed multiple trips and items for different users, request `GET /trips/{tripId}/items`, and verify the response contains only the selected owned trip's items, returns an empty list for an owned empty trip, returns `404 Not Found` for a missing trip, and returns forbidden for a foreign trip
 
 ### Tests for User Story 1
 
 - [ ] T013 [P] [US1] Add item domain and aggregate tests for trip-scoped item listing behavior in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
-- [ ] T014 [P] [US1] Add list-items application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs`
-- [ ] T015 [P] [US1] Add list-items integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
+- [ ] T014 [P] [US1] Add list-items application unit tests covering owned-trip, foreign-trip, and missing-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs`
+- [ ] T015 [P] [US1] Add list-items integration tests covering owned-trip, empty-trip, missing-trip, and foreign-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
 
 ### Implementation for User Story 1
 
 - [ ] T016 [P] [US1] Create list-items query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs`
 - [ ] T017 [P] [US1] Create list-items response mapping models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`
-- [ ] T018 [US1] Implement list-items application logic with ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
-- [ ] T019 [US1] Implement the `listItemsByTrip` endpoint with exact OpenAPI naming and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs`
+- [ ] T018 [US1] Implement list-items application logic with ownership enforcement and missing-trip `404 Not Found` handling in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
+- [ ] T019 [US1] Implement the `listItemsByTrip` endpoint with exact OpenAPI naming, structured logging, and missing-trip failure mapping in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs`
 
 **Checkpoint**: User Story 1 should be fully functional and testable independently
 
@@ -70,20 +70,20 @@
 
 **Goal**: Create a new item directly under an owned trip and assign it to the trip's default baggage
 
-**Independent Test**: Submit `POST /trips/{tripId}/items` for an owned trip and verify the created item has a new UUID, the correct trip id, a resolved default baggage id, and forbidden or validation failures for foreign trips and bad requests
+**Independent Test**: Submit `POST /trips/{tripId}/items` for an owned trip and verify the created item has a new UUID, the correct trip id, a resolved default baggage id, and that missing-trip, forbidden, or validation failures are returned for invalid scenarios
 
 ### Tests for User Story 2
 
 - [ ] T020 [P] [US2] Add default-baggage item creation domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
-- [ ] T021 [P] [US2] Add create-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs`
-- [ ] T022 [P] [US2] Add create-item integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs`
+- [ ] T021 [P] [US2] Add create-item application unit tests covering owned-trip, missing-trip, and foreign-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs`
+- [ ] T022 [P] [US2] Add create-item integration tests covering success, missing-trip, foreign-trip, and bad-request outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs`
 
 ### Implementation for User Story 2
 
 - [ ] T023 [P] [US2] Create create-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs`
 - [ ] T024 [P] [US2] Create create-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripRequest.cs`
-- [ ] T025 [US2] Implement create-item application logic with ownership checks and default baggage assignment in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs`
-- [ ] T026 [US2] Implement the `createItemInTrip` endpoint with exact OpenAPI naming, validation handling, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs`
+- [ ] T025 [US2] Implement create-item application logic with ownership checks, default baggage assignment, and missing-trip `404 Not Found` handling in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs`
+- [ ] T026 [US2] Implement the `createItemInTrip` endpoint with exact OpenAPI naming, validation handling, structured logging, and missing-trip failure mapping in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs`
 
 **Checkpoint**: User Stories 1 and 2 should both work independently
 

--- a/specs/002-trip-items-api/tasks.md
+++ b/specs/002-trip-items-api/tasks.md
@@ -17,10 +17,10 @@
 
 **Purpose**: Prepare solution and test scaffolding for the item feature
 
-- [ ] T001 Add any required item-feature package or project reference updates in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.csproj`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj`
-- [ ] T002 [P] Create item test folders and placeholder coverage files in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/`
-- [ ] T003 [P] Create item application and API folders in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/`
-- [ ] T004 Confirm the new item files are included in `/home/sicor/local-repos/maletapp/Maletapp.sln` where needed for build and test discovery
+- [X] T001 Add any required item-feature package or project reference updates in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.csproj`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj`
+- [X] T002 [P] Create item test folders and placeholder coverage files in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/`
+- [X] T003 [P] Create item application and API folders in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/`
+- [X] T004 Confirm the new item files are included in `/home/sicor/local-repos/maletapp/Maletapp.sln` where needed for build and test discovery
 
 ---
 
@@ -30,14 +30,14 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T005 Extend repository abstractions for trip item list, create, item lookup, and item update flows in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`
-- [ ] T006 [P] Create shared item DTOs for contract-aligned read and write models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/ItemDto.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/NewItemDto.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/PatchItemDto.cs`
-- [ ] T007 [P] Align the item and baggage domain behaviors for rename, default baggage assignment, and UUID-backed references in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Baggage.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Trip.cs`
-- [ ] T008 [P] Expand EF Core persistence models and configuration to store trips with nested baggages and items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/BaggageDataModel.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs`
-- [ ] T009 [P] Implement repository mapping and persistence support for nested baggages and items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
-- [ ] T010 [P] Create shared item endpoint naming and logging helpers in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointNames.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemLogMessages.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs`
-- [ ] T011 [P] Register item handlers and endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
-- [ ] T012 [P] Extend integration test infrastructure for owned-trip and foreign-trip item scenarios in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs`
+- [X] T005 Extend repository abstractions for trip item list, create, item lookup, and item update flows in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`
+- [X] T006 [P] Create shared item DTOs for contract-aligned read and write models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/ItemDto.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/NewItemDto.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/PatchItemDto.cs`
+- [X] T007 [P] Align the item and baggage domain behaviors for rename, default baggage assignment, and UUID-backed references in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Baggage.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Trip.cs`
+- [X] T008 [P] Expand EF Core persistence models and configuration to store trips with nested baggages and items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/BaggageDataModel.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs`
+- [X] T009 [P] Implement repository mapping and persistence support for nested baggages and items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [X] T010 [P] Create shared item endpoint naming and logging helpers in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointNames.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemLogMessages.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs`
+- [X] T011 [P] Register item handlers and endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
+- [X] T012 [P] Extend integration test infrastructure for owned-trip and foreign-trip item scenarios in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin
 
@@ -51,16 +51,16 @@
 
 ### Tests for User Story 1
 
-- [ ] T013 [P] [US1] Add item domain and aggregate tests for trip-scoped item listing behavior in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
-- [ ] T014 [P] [US1] Add list-items application unit tests covering owned-trip, foreign-trip, and missing-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs`
-- [ ] T015 [P] [US1] Add list-items integration tests covering owned-trip, empty-trip, missing-trip, and foreign-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
+- [X] T013 [P] [US1] Add item domain and aggregate tests for trip-scoped item listing behavior in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
+- [X] T014 [P] [US1] Add list-items application unit tests covering owned-trip, foreign-trip, and missing-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs`
+- [X] T015 [P] [US1] Add list-items integration tests covering owned-trip, empty-trip, missing-trip, and foreign-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T016 [P] [US1] Create list-items query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs`
-- [ ] T017 [P] [US1] Create list-items response mapping models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`
-- [ ] T018 [US1] Implement list-items application logic with ownership enforcement and missing-trip `404 Not Found` handling in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
-- [ ] T019 [US1] Implement the `listItemsByTrip` endpoint with exact OpenAPI naming, structured logging, and missing-trip failure mapping in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs`
+- [X] T016 [P] [US1] Create list-items query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs`
+- [X] T017 [P] [US1] Create list-items response mapping models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`
+- [X] T018 [US1] Implement list-items application logic with ownership enforcement and missing-trip `404 Not Found` handling in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
+- [X] T019 [US1] Implement the `listItemsByTrip` endpoint with exact OpenAPI naming, structured logging, and missing-trip failure mapping in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs`
 
 **Checkpoint**: User Story 1 should be fully functional and testable independently
 
@@ -74,16 +74,16 @@
 
 ### Tests for User Story 2
 
-- [ ] T020 [P] [US2] Add default-baggage item creation domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
-- [ ] T021 [P] [US2] Add create-item application unit tests covering owned-trip, missing-trip, and foreign-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs`
-- [ ] T022 [P] [US2] Add create-item integration tests covering success, missing-trip, foreign-trip, and bad-request outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs`
+- [X] T020 [P] [US2] Add default-baggage item creation domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [X] T021 [P] [US2] Add create-item application unit tests covering owned-trip, missing-trip, and foreign-trip outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs`
+- [X] T022 [P] [US2] Add create-item integration tests covering success, missing-trip, foreign-trip, and bad-request outcomes in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T023 [P] [US2] Create create-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs`
-- [ ] T024 [P] [US2] Create create-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripRequest.cs`
-- [ ] T025 [US2] Implement create-item application logic with ownership checks, default baggage assignment, and missing-trip `404 Not Found` handling in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs`
-- [ ] T026 [US2] Implement the `createItemInTrip` endpoint with exact OpenAPI naming, validation handling, structured logging, and missing-trip failure mapping in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs`
+- [X] T023 [P] [US2] Create create-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs`
+- [X] T024 [P] [US2] Create create-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripRequest.cs`
+- [X] T025 [US2] Implement create-item application logic with ownership checks, default baggage assignment, and missing-trip `404 Not Found` handling in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs`
+- [X] T026 [US2] Implement the `createItemInTrip` endpoint with exact OpenAPI naming, validation handling, structured logging, and missing-trip failure mapping in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs`
 
 **Checkpoint**: User Stories 1 and 2 should both work independently
 
@@ -97,20 +97,20 @@
 
 ### Tests for User Story 3
 
-- [ ] T027 [P] [US3] Add single-item retrieval and patch domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
-- [ ] T028 [P] [US3] Add get-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/GetItemHandlerTests.cs`
-- [ ] T029 [P] [US3] Add patch-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs`
-- [ ] T030 [P] [US3] Add get-item and patch-item integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/PatchItemEndpointTests.cs`
+- [X] T027 [P] [US3] Add single-item retrieval and patch domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [X] T028 [P] [US3] Add get-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/GetItemHandlerTests.cs`
+- [X] T029 [P] [US3] Add patch-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs`
+- [X] T030 [P] [US3] Add get-item and patch-item integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/PatchItemEndpointTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T031 [P] [US3] Create get-item query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemResult.cs`
-- [ ] T032 [P] [US3] Create patch-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemResult.cs`
-- [ ] T033 [P] [US3] Create patch-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemRequest.cs`
-- [ ] T034 [US3] Implement get-item application logic with ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs`
-- [ ] T035 [US3] Implement patch-item application logic for allowed item fields in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemHandler.cs`
-- [ ] T036 [US3] Implement the `getItem` endpoint with exact OpenAPI naming and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/GetItemEndpoint.cs`
-- [ ] T037 [US3] Implement the `patchItem` endpoint with exact OpenAPI naming, validation handling, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemEndpoint.cs`
+- [X] T031 [P] [US3] Create get-item query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemResult.cs`
+- [X] T032 [P] [US3] Create patch-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemResult.cs`
+- [X] T033 [P] [US3] Create patch-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemRequest.cs`
+- [X] T034 [US3] Implement get-item application logic with ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs`
+- [X] T035 [US3] Implement patch-item application logic for allowed item fields in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemHandler.cs`
+- [X] T036 [US3] Implement the `getItem` endpoint with exact OpenAPI naming and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/GetItemEndpoint.cs`
+- [X] T037 [US3] Implement the `patchItem` endpoint with exact OpenAPI naming, validation handling, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemEndpoint.cs`
 
 **Checkpoint**: All user stories should now be independently functional
 
@@ -120,9 +120,9 @@
 
 **Purpose**: Final cross-story cleanup and verification
 
-- [ ] T038 [P] Update Swagger and HTTP examples for the item endpoints in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.http`
-- [ ] T039 [P] Add any missing shared test helpers for item scenarios in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs`
-- [ ] T040 Run the full verification flow from `/home/sicor/local-repos/maletapp/specs/002-trip-items-api/quickstart.md`
+- [X] T038 [P] Update Swagger and HTTP examples for the item endpoints in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.http`
+- [X] T039 [P] Add any missing shared test helpers for item scenarios in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs`
+- [X] T040 Run the full verification flow from `/home/sicor/local-repos/maletapp/specs/002-trip-items-api/quickstart.md`
 
 ---
 

--- a/specs/002-trip-items-api/tasks.md
+++ b/specs/002-trip-items-api/tasks.md
@@ -1,0 +1,228 @@
+# Tasks: Trip Item Access
+
+**Input**: Design documents from `/specs/002-trip-items-api/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Unit and integration tests are required for this feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare solution and test scaffolding for the item feature
+
+- [ ] T001 Add any required item-feature package or project reference updates in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.csproj`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Trip.API.UnitTests.csproj`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Trip.API.IntegrationTests.csproj`
+- [ ] T002 [P] Create item test folders and placeholder coverage files in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/`
+- [ ] T003 [P] Create item application and API folders in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/`
+- [ ] T004 Confirm the new item files are included in `/home/sicor/local-repos/maletapp/Maletapp.sln` where needed for build and test discovery
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before any user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T005 Extend repository abstractions for trip item list, create, item lookup, and item update flows in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`
+- [ ] T006 [P] Create shared item DTOs for contract-aligned read and write models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/ItemDto.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/NewItemDto.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Dtos/PatchItemDto.cs`
+- [ ] T007 [P] Align the item and baggage domain behaviors for rename, default baggage assignment, and UUID-backed references in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Baggage.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Trip.cs`
+- [ ] T008 [P] Expand EF Core persistence models and configuration to store trips with nested baggages and items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/BaggageDataModel.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs`
+- [ ] T009 [P] Implement repository mapping and persistence support for nested baggages and items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [ ] T010 [P] Create shared item endpoint naming and logging helpers in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointNames.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemLogMessages.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs`
+- [ ] T011 [P] Register item handlers and endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
+- [ ] T012 [P] Extend integration test infrastructure for owned-trip and foreign-trip item scenarios in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TestUserContextHeaderNames.cs`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - View items for my trip (Priority: P1) 🎯 MVP
+
+**Goal**: Return all items for one owned trip and deny access to foreign trips
+
+**Independent Test**: Seed multiple trips and items for different users, request `GET /trips/{tripId}/items`, and verify the response contains only the selected owned trip's items, returns an empty list for an owned empty trip, and returns forbidden for a foreign trip
+
+### Tests for User Story 1
+
+- [ ] T013 [P] [US1] Add item domain and aggregate tests for trip-scoped item listing behavior in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs`
+- [ ] T014 [P] [US1] Add list-items application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs`
+- [ ] T015 [P] [US1] Add list-items integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T016 [P] [US1] Create list-items query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs`
+- [ ] T017 [P] [US1] Create list-items response mapping models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`
+- [ ] T018 [US1] Implement list-items application logic with ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
+- [ ] T019 [US1] Implement the `listItemsByTrip` endpoint with exact OpenAPI naming and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs`
+
+**Checkpoint**: User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Add an item to my trip (Priority: P2)
+
+**Goal**: Create a new item directly under an owned trip and assign it to the trip's default baggage
+
+**Independent Test**: Submit `POST /trips/{tripId}/items` for an owned trip and verify the created item has a new UUID, the correct trip id, a resolved default baggage id, and forbidden or validation failures for foreign trips and bad requests
+
+### Tests for User Story 2
+
+- [ ] T020 [P] [US2] Add default-baggage item creation domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [ ] T021 [P] [US2] Add create-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs`
+- [ ] T022 [P] [US2] Add create-item integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T023 [P] [US2] Create create-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs`
+- [ ] T024 [P] [US2] Create create-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripRequest.cs`
+- [ ] T025 [US2] Implement create-item application logic with ownership checks and default baggage assignment in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs`
+- [ ] T026 [US2] Implement the `createItemInTrip` endpoint with exact OpenAPI naming, validation handling, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs`
+
+**Checkpoint**: User Stories 1 and 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - View or update a specific item I own (Priority: P3)
+
+**Goal**: Retrieve a single owned item and partially update its allowed fields while preserving trip ownership rules
+
+**Independent Test**: Request `GET /items/{itemId}` and `PATCH /items/{itemId}` for an owned item, verify the correct item is returned and updated, and verify not-found, forbidden, invalid-body, and missing-user failures
+
+### Tests for User Story 3
+
+- [ ] T027 [P] [US3] Add single-item retrieval and patch domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [ ] T028 [P] [US3] Add get-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/GetItemHandlerTests.cs`
+- [ ] T029 [P] [US3] Add patch-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs`
+- [ ] T030 [P] [US3] Add get-item and patch-item integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/PatchItemEndpointTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T031 [P] [US3] Create get-item query and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemQuery.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemResult.cs`
+- [ ] T032 [P] [US3] Create patch-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemResult.cs`
+- [ ] T033 [P] [US3] Create patch-item request models in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemRequest.cs`
+- [ ] T034 [US3] Implement get-item application logic with ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs`
+- [ ] T035 [US3] Implement patch-item application logic for allowed item fields in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemHandler.cs`
+- [ ] T036 [US3] Implement the `getItem` endpoint with exact OpenAPI naming and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/GetItemEndpoint.cs`
+- [ ] T037 [US3] Implement the `patchItem` endpoint with exact OpenAPI naming, validation handling, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemEndpoint.cs`
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cross-story cleanup and verification
+
+- [ ] T038 [P] Update Swagger and HTTP examples for the item endpoints in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.http`
+- [ ] T039 [P] Add any missing shared test helpers for item scenarios in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs` and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Infrastructure/TripApiFactory.cs`
+- [ ] T040 Run the full verification flow from `/home/sicor/local-repos/maletapp/specs/002-trip-items-api/quickstart.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion; is the MVP
+- **User Story 2 (Phase 4)**: Depends on Foundational completion and practically benefits from US1 list coverage for seeded trip/item data
+- **User Story 3 (Phase 5)**: Depends on Foundational completion and reuses shared item DTOs, repository support, and endpoint routing from earlier phases
+- **Polish (Phase 6)**: Depends on all implemented user stories
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories
+- **US2**: No strict dependency on US1, but verification benefits from the same seeded item and trip infrastructure
+- **US3**: No strict dependency on US1 or US2, but verification benefits from an existing persisted item
+
+### Within Each User Story
+
+- Tests must be written before the corresponding implementation tasks
+- Query and command models before handlers
+- Handlers before endpoints
+- Story verification after endpoint completion
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel after T001
+- T006, T007, T008, T009, T010, T011, and T012 can run in parallel after T005 where dependencies allow
+- For US1, T013, T014, T015, T016, and T017 can run in parallel before T018 and T019
+- For US2, T020, T021, T022, T023, and T024 can run in parallel before T025 and T026
+- For US3, T027, T028, T029, T030, T031, T032, and T033 can run in parallel before T034, T035, T036, and T037
+- T038 and T039 can run in parallel before T040
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add item domain and aggregate tests for trip-scoped item listing in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs and /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Testing/TripFixtures.cs"
+Task: "Add list-items application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs"
+Task: "Add list-items integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs"
+Task: "Create list-items query and result models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs"
+Task: "Create list-items response mapping models in /home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add default-baggage item creation domain tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs"
+Task: "Add create-item application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs"
+Task: "Add create-item integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs"
+Task: "Create create-item command and result models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs"
+Task: "Create create-item request models in /home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CreateItemInTripRequest.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Add get-item application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/GetItemHandlerTests.cs"
+Task: "Add patch-item application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs"
+Task: "Add get-item and patch-item integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs and /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/PatchItemEndpointTests.cs"
+Task: "Create get-item query and result models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemQuery.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemResult.cs"
+Task: "Create patch-item command and result models in /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemCommand.cs and /home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/PatchItem/PatchItemResult.cs"
+Task: "Create patch-item request models in /home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/PatchItemRequest.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate trip item listing behavior independently
+5. Commit the completed task work before moving to the next story
+
+### Incremental Delivery
+
+1. Complete Setup and Foundational work once
+2. Deliver US1 as the MVP
+3. Deliver US2 as the next independently testable increment
+4. Deliver US3 as the final functional increment
+5. Finish with cross-cutting verification and cleanup
+
+### Parallel Team Strategy
+
+1. One engineer can expand persistence and repository support while another prepares item DTOs and endpoint scaffolding during Phase 2
+2. After Phase 2, one engineer can implement US1 while another prepares US2 tests and a third prepares US3 request and query models
+3. Complete each story, verify it independently, then merge in priority order
+
+---
+
+## Notes
+
+- Every task follows the required checklist format with an ID, optional parallel marker, required story label for story work, and exact file paths
+- Tests are intentionally included because the feature specification and constitution require automated validation
+- US1 is the suggested MVP scope
+- Commit after each completed `speckit.tasks` task or tight logical batch per repository guidance

--- a/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs
+++ b/src/Trip.API/Api/Items/CreateItemInTripEndpoint.cs
@@ -1,0 +1,50 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.CreateItemInTrip;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Api.Items;
+
+public static class CreateItemInTripEndpoint
+{
+    public static IEndpointRouteBuilder MapCreateItemInTrip(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost(
+                "/trips/{tripId:guid}/items",
+                async Task<IResult> (
+                    Guid tripId,
+                    CreateItemInTripRequest request,
+                    IUserContextAccessor userContextAccessor,
+                    CreateItemInTripHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(CreateItemInTripEndpoint));
+                    logger.CreateItemInTripRequestReceived(userId.Value, tripId);
+
+                    var result = await handler.HandleAsync(
+                        new CreateItemInTripCommand(
+                            userId,
+                            TripId.FromGuid(tripId),
+                            new NewItemDto(request.Name, request.DefaultItemId)),
+                        cancellationToken);
+
+                    var item = result.Item;
+                    return Results.Created($"/items/{item.Id}", new ItemResponse(
+                        item.Id,
+                        item.TripId,
+                        item.BaggageId,
+                        item.Name,
+                        item.CheckCount,
+                        item.DefaultItemId));
+                })
+            .WithName(ItemEndpointNames.CreateItemInTrip)
+            .WithTags("Items");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Items/CreateItemInTripRequest.cs
+++ b/src/Trip.API/Api/Items/CreateItemInTripRequest.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Api.Items;
+
+public sealed record CreateItemInTripRequest(string Name, Guid? DefaultItemId);

--- a/src/Trip.API/Api/Items/GetItemEndpoint.cs
+++ b/src/Trip.API/Api/Items/GetItemEndpoint.cs
@@ -1,0 +1,45 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.GetItem;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Api.Items;
+
+public static class GetItemEndpoint
+{
+    public static IEndpointRouteBuilder MapGetItem(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(
+                "/items/{itemId:guid}",
+                async Task<IResult> (
+                    Guid itemId,
+                    IUserContextAccessor userContextAccessor,
+                    GetItemHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(GetItemEndpoint));
+                    logger.GetItemRequestReceived(userId.Value, itemId);
+
+                    var result = await handler.HandleAsync(
+                        new GetItemQuery(userId, ItemId.FromGuid(itemId)),
+                        cancellationToken);
+
+                    var item = result.Item;
+                    return Results.Ok(new ItemResponse(
+                        item.Id,
+                        item.TripId,
+                        item.BaggageId,
+                        item.Name,
+                        item.CheckCount,
+                        item.DefaultItemId));
+                })
+            .WithName(ItemEndpointNames.GetItem)
+            .WithTags("Items");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Items/ItemEndpointNames.cs
+++ b/src/Trip.API/Api/Items/ItemEndpointNames.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Api.Items;
+
+public static class ItemEndpointNames
+{
+    public const string ListItemsByTrip = "listItemsByTrip";
+    public const string CreateItemInTrip = "createItemInTrip";
+    public const string GetItem = "getItem";
+    public const string PatchItem = "patchItem";
+}

--- a/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs
+++ b/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs
@@ -1,0 +1,14 @@
+namespace Trip.API.Api.Items;
+
+public static class ItemEndpointRouteBuilderExtensions
+{
+    public static IEndpointRouteBuilder MapItemEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapListItemsByTrip();
+        endpoints.MapCreateItemInTrip();
+        endpoints.MapGetItem();
+        endpoints.MapPatchItem();
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Items/ItemLogMessages.cs
+++ b/src/Trip.API/Api/Items/ItemLogMessages.cs
@@ -1,0 +1,16 @@
+namespace Trip.API.Api.Items;
+
+internal static partial class ItemLogMessages
+{
+    [LoggerMessage(EventId = 1100, Level = LogLevel.Information, Message = "Received list items request for user {UserId} and trip {TripId}")]
+    public static partial void ListItemsByTripRequestReceived(this ILogger logger, Guid userId, Guid tripId);
+
+    [LoggerMessage(EventId = 1101, Level = LogLevel.Information, Message = "Received create item request for user {UserId} and trip {TripId}")]
+    public static partial void CreateItemInTripRequestReceived(this ILogger logger, Guid userId, Guid tripId);
+
+    [LoggerMessage(EventId = 1102, Level = LogLevel.Information, Message = "Received get item request for user {UserId} and item {ItemId}")]
+    public static partial void GetItemRequestReceived(this ILogger logger, Guid userId, Guid itemId);
+
+    [LoggerMessage(EventId = 1103, Level = LogLevel.Information, Message = "Received patch item request for user {UserId} and item {ItemId}")]
+    public static partial void PatchItemRequestReceived(this ILogger logger, Guid userId, Guid itemId);
+}

--- a/src/Trip.API/Api/Items/ItemResponse.cs
+++ b/src/Trip.API/Api/Items/ItemResponse.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Api.Items;
+
+public sealed record ItemResponse(
+    Guid Id,
+    Guid TripId,
+    Guid BaggageId,
+    string Name,
+    int CheckCount,
+    Guid? DefaultItemId);

--- a/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs
+++ b/src/Trip.API/Api/Items/ListItemsByTripEndpoint.cs
@@ -1,0 +1,45 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.ListItemsByTrip;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Api.Items;
+
+public static class ListItemsByTripEndpoint
+{
+    public static IEndpointRouteBuilder MapListItemsByTrip(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet(
+                "/trips/{tripId:guid}/items",
+                async Task<IResult> (
+                    Guid tripId,
+                    IUserContextAccessor userContextAccessor,
+                    ListItemsByTripHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(ListItemsByTripEndpoint));
+                    logger.ListItemsByTripRequestReceived(userId.Value, tripId);
+
+                    var result = await handler.HandleAsync(
+                        new ListItemsByTripQuery(userId, TripId.FromGuid(tripId)),
+                        cancellationToken);
+
+                    return Results.Ok(result.Items
+                        .Select(item => new ItemResponse(
+                            item.Id,
+                            item.TripId,
+                            item.BaggageId,
+                            item.Name,
+                            item.CheckCount,
+                            item.DefaultItemId)));
+                })
+            .WithName(ItemEndpointNames.ListItemsByTrip)
+            .WithTags("Items");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Items/PatchItemEndpoint.cs
+++ b/src/Trip.API/Api/Items/PatchItemEndpoint.cs
@@ -1,0 +1,55 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.PatchItem;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Api.Items;
+
+public static class PatchItemEndpoint
+{
+    public static IEndpointRouteBuilder MapPatchItem(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapMethods(
+                "/items/{itemId:guid}",
+                new[] { "PATCH" },
+                async Task<IResult> (
+                    Guid itemId,
+                    PatchItemRequest request,
+                    IUserContextAccessor userContextAccessor,
+                    PatchItemHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(PatchItemEndpoint));
+                    logger.PatchItemRequestReceived(userId.Value, itemId);
+
+                    var result = await handler.HandleAsync(
+                        new PatchItemCommand(
+                            userId,
+                            ItemId.FromGuid(itemId),
+                            new PatchItemDto(
+                                request.Name,
+                                request.HasName,
+                                request.DefaultItemId,
+                                request.HasDefaultItemId)),
+                        cancellationToken);
+
+                    var item = result.Item;
+                    return Results.Ok(new ItemResponse(
+                        item.Id,
+                        item.TripId,
+                        item.BaggageId,
+                        item.Name,
+                        item.CheckCount,
+                        item.DefaultItemId));
+                })
+            .WithName(ItemEndpointNames.PatchItem)
+            .WithTags("Items");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Items/PatchItemRequest.cs
+++ b/src/Trip.API/Api/Items/PatchItemRequest.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace Trip.API.Api.Items;
+
+public sealed class PatchItemRequest
+{
+    public string? Name { get; init; }
+    public bool HasName { get; init; }
+    public Guid? DefaultItemId { get; init; }
+    public bool HasDefaultItemId { get; init; }
+
+    public static async ValueTask<PatchItemRequest?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        var request = context.Request;
+
+        if (request.ContentLength is 0)
+        {
+            return new PatchItemRequest();
+        }
+
+        using var document = await JsonDocument.ParseAsync(request.Body, cancellationToken: context.RequestAborted).ConfigureAwait(false);
+        var root = document.RootElement;
+
+        string? name = null;
+        var hasName = root.TryGetProperty("name", out var nameElement);
+        if (hasName && nameElement.ValueKind != JsonValueKind.Null)
+        {
+            name = nameElement.GetString();
+        }
+
+        Guid? defaultItemId = null;
+        var hasDefaultItemId = root.TryGetProperty("defaultItemId", out var defaultItemIdElement);
+        if (hasDefaultItemId && defaultItemIdElement.ValueKind != JsonValueKind.Null)
+        {
+            if (defaultItemIdElement.ValueKind != JsonValueKind.String
+                || !Guid.TryParse(defaultItemIdElement.GetString(), out var parsedDefaultItemId))
+            {
+                throw new BadHttpRequestException("The JSON value could not be converted to System.Guid.");
+            }
+
+            defaultItemId = parsedDefaultItemId;
+        }
+
+        return new PatchItemRequest
+        {
+            Name = name,
+            HasName = hasName,
+            DefaultItemId = defaultItemId,
+            HasDefaultItemId = hasDefaultItemId
+        };
+    }
+}

--- a/src/Trip.API/Application/Abstractions/ITripRepository.cs
+++ b/src/Trip.API/Application/Abstractions/ITripRepository.cs
@@ -8,7 +8,11 @@ public interface ITripRepository
 {
     Task AddAsync(TripEntity trip, CancellationToken cancellationToken);
 
+    Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken);
+
     Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken);
 
     Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken);
+
+    Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken);
 }

--- a/src/Trip.API/Application/Dtos/ItemDto.cs
+++ b/src/Trip.API/Application/Dtos/ItemDto.cs
@@ -1,0 +1,9 @@
+namespace Trip.API.Application.Dtos;
+
+public sealed record ItemDto(
+    Guid Id,
+    Guid TripId,
+    Guid BaggageId,
+    string Name,
+    int CheckCount,
+    Guid? DefaultItemId);

--- a/src/Trip.API/Application/Dtos/NewItemDto.cs
+++ b/src/Trip.API/Application/Dtos/NewItemDto.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Application.Dtos;
+
+public sealed record NewItemDto(string Name, Guid? DefaultItemId);

--- a/src/Trip.API/Application/Dtos/PatchItemDto.cs
+++ b/src/Trip.API/Application/Dtos/PatchItemDto.cs
@@ -1,0 +1,3 @@
+namespace Trip.API.Application.Dtos;
+
+public sealed record PatchItemDto(string? Name, bool HasName, Guid? DefaultItemId, bool HasDefaultItemId);

--- a/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs
+++ b/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripCommand.cs
@@ -1,0 +1,6 @@
+using Trip.API.Application.Dtos;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Items.CreateItemInTrip;
+
+public sealed record CreateItemInTripCommand(UserId UserId, TripId TripId, NewItemDto Item);

--- a/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs
+++ b/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripHandler.cs
@@ -1,0 +1,50 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Application.Items.CreateItemInTrip;
+
+public sealed class CreateItemInTripHandler
+{
+    private readonly ILogger<CreateItemInTripHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public CreateItemInTripHandler(ITripRepository tripRepository, ILogger<CreateItemInTripHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<CreateItemInTripResult> HandleAsync(CreateItemInTripCommand command, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Creating item in trip {TripId} for user {UserId}", command.TripId.Value, command.UserId.Value);
+
+        if (string.IsNullOrWhiteSpace(command.Item.Name))
+        {
+            throw new ValidationException("Item name is required.");
+        }
+
+        var trip = await _tripRepository.GetByIdAsync(command.TripId, cancellationToken).ConfigureAwait(false);
+
+        if (trip is null)
+        {
+            throw new NotFoundException($"Trip {command.TripId.Value} was not found.");
+        }
+
+        if (trip.OwnerId != command.UserId)
+        {
+            throw new ForbiddenException($"Trip {command.TripId.Value} is not accessible for the current user.");
+        }
+
+        var item = trip.AddItemToDefaultBaggage(command.Item.Name, command.Item.DefaultItemId);
+        await _tripRepository.UpdateAsync(trip, cancellationToken).ConfigureAwait(false);
+
+        return new CreateItemInTripResult(new ItemDto(
+            item.Id.Value,
+            item.TripId.Value,
+            item.BaggageId.Value,
+            item.Name,
+            item.CheckCount,
+            item.DefaultItemId));
+    }
+}

--- a/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs
+++ b/src/Trip.API/Application/Items/CreateItemInTrip/CreateItemInTripResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Items.CreateItemInTrip;
+
+public sealed record CreateItemInTripResult(ItemDto Item);

--- a/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs
+++ b/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs
@@ -1,0 +1,45 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Application.Items.GetItem;
+
+public sealed class GetItemHandler
+{
+    private readonly ILogger<GetItemHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public GetItemHandler(ITripRepository tripRepository, ILogger<GetItemHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<GetItemResult> HandleAsync(GetItemQuery query, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Retrieving item {ItemId} for user {UserId}", query.ItemId.Value, query.UserId.Value);
+
+        var trip = await _tripRepository.GetTripByItemIdAsync(query.ItemId, cancellationToken).ConfigureAwait(false);
+
+        if (trip is null)
+        {
+            throw new NotFoundException($"Item {query.ItemId.Value} was not found.");
+        }
+
+        if (trip.OwnerId != query.UserId)
+        {
+            throw new ForbiddenException($"Item {query.ItemId.Value} is not accessible for the current user.");
+        }
+
+        var item = trip.FindItem(query.ItemId)
+            ?? throw new NotFoundException($"Item {query.ItemId.Value} was not found.");
+
+        return new GetItemResult(new ItemDto(
+            item.Id.Value,
+            item.TripId.Value,
+            item.BaggageId.Value,
+            item.Name,
+            item.CheckCount,
+            item.DefaultItemId));
+    }
+}

--- a/src/Trip.API/Application/Items/GetItem/GetItemQuery.cs
+++ b/src/Trip.API/Application/Items/GetItem/GetItemQuery.cs
@@ -1,0 +1,5 @@
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Items.GetItem;
+
+public sealed record GetItemQuery(UserId UserId, ItemId ItemId);

--- a/src/Trip.API/Application/Items/GetItem/GetItemResult.cs
+++ b/src/Trip.API/Application/Items/GetItem/GetItemResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Items.GetItem;
+
+public sealed record GetItemResult(ItemDto Item);

--- a/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs
+++ b/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs
@@ -1,0 +1,44 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Application.Items.ListItemsByTrip;
+
+public sealed class ListItemsByTripHandler
+{
+    private readonly ILogger<ListItemsByTripHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public ListItemsByTripHandler(ITripRepository tripRepository, ILogger<ListItemsByTripHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<ListItemsByTripResult> HandleAsync(ListItemsByTripQuery query, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Listing items for trip {TripId} and user {UserId}", query.TripId.Value, query.UserId.Value);
+
+        var trip = await _tripRepository.GetByIdAsync(query.TripId, cancellationToken).ConfigureAwait(false);
+
+        if (trip is null)
+        {
+            throw new NotFoundException($"Trip {query.TripId.Value} was not found.");
+        }
+
+        if (trip.OwnerId != query.UserId)
+        {
+            throw new ForbiddenException($"Trip {query.TripId.Value} is not accessible for the current user.");
+        }
+
+        return new ListItemsByTripResult(trip.Items
+            .Select(item => new ItemDto(
+                item.Id.Value,
+                item.TripId.Value,
+                item.BaggageId.Value,
+                item.Name,
+                item.CheckCount,
+                item.DefaultItemId))
+            .ToArray());
+    }
+}

--- a/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs
+++ b/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripQuery.cs
@@ -1,0 +1,5 @@
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Items.ListItemsByTrip;
+
+public sealed record ListItemsByTripQuery(UserId UserId, TripId TripId);

--- a/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs
+++ b/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Items.ListItemsByTrip;
+
+public sealed record ListItemsByTripResult(IReadOnlyList<ItemDto> Items);

--- a/src/Trip.API/Application/Items/PatchItem/PatchItemCommand.cs
+++ b/src/Trip.API/Application/Items/PatchItem/PatchItemCommand.cs
@@ -1,0 +1,6 @@
+using Trip.API.Application.Dtos;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Items.PatchItem;
+
+public sealed record PatchItemCommand(UserId UserId, ItemId ItemId, PatchItemDto Item);

--- a/src/Trip.API/Application/Items/PatchItem/PatchItemHandler.cs
+++ b/src/Trip.API/Application/Items/PatchItem/PatchItemHandler.cs
@@ -1,0 +1,62 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Application.Items.PatchItem;
+
+public sealed class PatchItemHandler
+{
+    private readonly ILogger<PatchItemHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public PatchItemHandler(ITripRepository tripRepository, ILogger<PatchItemHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<PatchItemResult> HandleAsync(PatchItemCommand command, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Patching item {ItemId} for user {UserId}", command.ItemId.Value, command.UserId.Value);
+
+        var trip = await _tripRepository.GetTripByItemIdAsync(command.ItemId, cancellationToken).ConfigureAwait(false);
+
+        if (trip is null)
+        {
+            throw new NotFoundException($"Item {command.ItemId.Value} was not found.");
+        }
+
+        if (trip.OwnerId != command.UserId)
+        {
+            throw new ForbiddenException($"Item {command.ItemId.Value} is not accessible for the current user.");
+        }
+
+        var item = trip.FindItem(command.ItemId)
+            ?? throw new NotFoundException($"Item {command.ItemId.Value} was not found.");
+
+        if (command.Item.HasName)
+        {
+            if (string.IsNullOrWhiteSpace(command.Item.Name))
+            {
+                throw new ValidationException("Item name cannot be empty.");
+            }
+
+            item.Rename(command.Item.Name!);
+        }
+
+        if (command.Item.HasDefaultItemId)
+        {
+            item.UpdateDefaultItemId(command.Item.DefaultItemId);
+        }
+
+        await _tripRepository.UpdateAsync(trip, cancellationToken).ConfigureAwait(false);
+
+        return new PatchItemResult(new ItemDto(
+            item.Id.Value,
+            item.TripId.Value,
+            item.BaggageId.Value,
+            item.Name,
+            item.CheckCount,
+            item.DefaultItemId));
+    }
+}

--- a/src/Trip.API/Application/Items/PatchItem/PatchItemResult.cs
+++ b/src/Trip.API/Application/Items/PatchItem/PatchItemResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Items.PatchItem;
+
+public sealed record PatchItemResult(ItemDto Item);

--- a/src/Trip.API/Domain/Entities/Baggage.cs
+++ b/src/Trip.API/Domain/Entities/Baggage.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Trip.API.Domain.ValueObjects;
 using Trip.API.SeedWork;
+
 namespace Trip.API.Domain.Entities;
 
 public sealed class Baggage : IEntity
@@ -33,9 +34,26 @@ public sealed class Baggage : IEntity
         if (string.IsNullOrWhiteSpace(itemName))
             throw new ArgumentException("Item name cannot be empty.", nameof(itemName));
 
-        var item = new Item(ItemId.CreateUnique(), this.Id, itemName, defaultItemId);
+        var item = new Item(ItemId.CreateUnique(), TripId, Id, itemName, defaultItemId);
 
         _items.Add(item);
         return item;
+    }
+
+    public Item? FindItem(ItemId itemId)
+    {
+        return _items.SingleOrDefault(item => item.Id == itemId);
+    }
+
+    public static Baggage Rehydrate(BaggageId id, TripId tripId, string name, bool isDefaultBaggage, IEnumerable<Item>? items = null)
+    {
+        var baggage = new Baggage(id, tripId, name, isDefaultBaggage);
+
+        if (items is not null)
+        {
+            baggage._items.AddRange(items);
+        }
+
+        return baggage;
     }
 }

--- a/src/Trip.API/Domain/Entities/Item.cs
+++ b/src/Trip.API/Domain/Entities/Item.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Trip.API.Domain.ValueObjects;
 using Trip.API.SeedWork;
+
 namespace Trip.API.Domain.Entities;
 
 public sealed class Item : IEntity
@@ -8,12 +9,13 @@ public sealed class Item : IEntity
     private Item() { }
 
     [SetsRequiredMembers]
-    public Item(ItemId id, BaggageId baggageId, string name, Guid? defaultItemId = null)
+    public Item(ItemId id, TripId tripId, BaggageId baggageId, string name, Guid? defaultItemId = null)
     {
         Id = id ?? throw new ArgumentNullException(nameof(id));
+        TripId = tripId ?? throw new ArgumentNullException(nameof(tripId));
         BaggageId = baggageId ?? throw new ArgumentNullException(nameof(baggageId));
         Name = !string.IsNullOrWhiteSpace(name)
-            ? name
+            ? name.Trim()
             : throw new ArgumentException("Item name cannot be null or empty.", nameof(name));
 
         DefaultItemId = defaultItemId;
@@ -21,10 +23,26 @@ public sealed class Item : IEntity
     }
 
     public required ItemId Id { get; init; }
+    public required TripId TripId { get; init; }
     public required BaggageId BaggageId { get; init; }
-    public required string Name { get; set; }
+    public string Name { get; private set; } = string.Empty;
     public Guid? DefaultItemId { get; private set; }
     public int CheckCount { get; private set; }
+
+    public static Item Rehydrate(ItemId id, TripId tripId, BaggageId baggageId, string name, int checkCount, Guid? defaultItemId = null)
+    {
+        if (checkCount < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(checkCount), "Item check count cannot be negative.");
+        }
+
+        var item = new Item(id, tripId, baggageId, name, defaultItemId)
+        {
+            CheckCount = checkCount
+        };
+
+        return item;
+    }
 
     public void Check()
     {
@@ -36,7 +54,7 @@ public sealed class Item : IEntity
         if (string.IsNullOrWhiteSpace(newName))
             throw new ArgumentException("Item name cannot be empty.", nameof(newName));
 
-        Name = newName;
+        Name = newName.Trim();
     }
 
     public void UpdateDefaultItemId(Guid? defaultItemId)

--- a/src/Trip.API/Domain/Entities/Trip.cs
+++ b/src/Trip.API/Domain/Entities/Trip.cs
@@ -35,6 +35,10 @@ public sealed class Trip : IEntity
 
     public IReadOnlyCollection<Baggage> Baggages => _baggages.AsReadOnly();
 
+    public IReadOnlyCollection<Item> Items => _baggages
+        .SelectMany(baggage => baggage.Items)
+        .ToArray();
+
     public Baggage AddBaggage(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -76,6 +80,31 @@ public sealed class Trip : IEntity
         }
 
         return defaultBaggage.AddItem(itemName, defaultItemId);
+    }
+
+    public Item? FindItem(ItemId itemId)
+    {
+        return _baggages
+            .SelectMany(baggage => baggage.Items)
+            .SingleOrDefault(item => item.Id == itemId);
+    }
+
+    public static Trip Rehydrate(
+        TripId id,
+        UserId ownerId,
+        string destination,
+        DateOnly? startDate,
+        DateOnly? endDate,
+        IEnumerable<Baggage>? baggages = null)
+    {
+        var trip = new Trip(id, ownerId, destination, startDate, endDate);
+
+        if (baggages is not null)
+        {
+            trip._baggages.AddRange(baggages);
+        }
+
+        return trip;
     }
 
     private void ValidateDates()

--- a/src/Trip.API/Infrastructure/Persistence/BaggageDataModel.cs
+++ b/src/Trip.API/Infrastructure/Persistence/BaggageDataModel.cs
@@ -1,0 +1,16 @@
+namespace Trip.API.Infrastructure.Persistence;
+
+public sealed class BaggageDataModel
+{
+    public Guid Id { get; set; }
+
+    public Guid TripId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public bool IsDefaultBaggage { get; set; }
+
+    public TripDataModel? Trip { get; set; }
+
+    public List<ItemDataModel> Items { get; set; } = new();
+}

--- a/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs
+++ b/src/Trip.API/Infrastructure/Persistence/Configurations/TripConfiguration.cs
@@ -11,5 +11,10 @@ public sealed class TripConfiguration : IEntityTypeConfiguration<TripDataModel>
 
         builder.Property(trip => trip.Destination)
             .IsRequired();
+
+        builder.HasMany(trip => trip.Baggages)
+            .WithOne(baggage => baggage.Trip)
+            .HasForeignKey(baggage => baggage.TripId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs
+++ b/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs
@@ -1,0 +1,18 @@
+namespace Trip.API.Infrastructure.Persistence;
+
+public sealed class ItemDataModel
+{
+    public Guid Id { get; set; }
+
+    public Guid TripId { get; set; }
+
+    public Guid BaggageId { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public int CheckCount { get; set; }
+
+    public Guid? DefaultItemId { get; set; }
+
+    public BaggageDataModel? Baggage { get; set; }
+}

--- a/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs
+++ b/src/Trip.API/Infrastructure/Persistence/TripDataModel.cs
@@ -11,4 +11,6 @@ public sealed class TripDataModel
     public DateOnly? StartDate { get; set; }
 
     public DateOnly? EndDate { get; set; }
+
+    public List<BaggageDataModel> Baggages { get; set; } = new();
 }

--- a/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs
+++ b/src/Trip.API/Infrastructure/Persistence/TripDbContext.cs
@@ -10,6 +10,8 @@ public sealed class TripDbContext : DbContext
     }
 
     public DbSet<TripDataModel> Trips => Set<TripDataModel>();
+    public DbSet<BaggageDataModel> Baggages => Set<BaggageDataModel>();
+    public DbSet<ItemDataModel> Items => Set<ItemDataModel>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/Trip.API/Infrastructure/Repositories/TripRepository.cs
+++ b/src/Trip.API/Infrastructure/Repositories/TripRepository.cs
@@ -18,16 +18,43 @@ public sealed class TripRepository : ITripRepository
 
     public async Task AddAsync(TripEntity trip, CancellationToken cancellationToken)
     {
-        await _dbContext.Trips.AddAsync(
-            new TripDataModel
+        await _dbContext.Trips.AddAsync(MapTripDataModel(trip), cancellationToken).ConfigureAwait(false);
+
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken)
+    {
+        var existingTrip = await _dbContext.Trips
+            .Include(model => model.Baggages)
+            .ThenInclude(model => model.Items)
+            .SingleOrDefaultAsync(model => model.Id == trip.Id.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existingTrip is null)
+        {
+            throw new InvalidOperationException($"Trip {trip.Id.Value} was not found for update.");
+        }
+
+        existingTrip.OwnerId = trip.OwnerId.Value;
+        existingTrip.Destination = trip.Destination;
+        existingTrip.StartDate = trip.StartDate;
+        existingTrip.EndDate = trip.EndDate;
+
+        _dbContext.Items.RemoveRange(existingTrip.Baggages.SelectMany(baggage => baggage.Items).ToList());
+        _dbContext.Baggages.RemoveRange(existingTrip.Baggages.ToList());
+        existingTrip.Baggages.Clear();
+
+        foreach (var baggage in MapBaggageDataModels(trip))
+        {
+            existingTrip.Baggages.Add(baggage);
+            _dbContext.Entry(baggage).State = EntityState.Added;
+
+            foreach (var item in baggage.Items)
             {
-                Id = trip.Id.Value,
-                OwnerId = trip.OwnerId.Value,
-                Destination = trip.Destination,
-                StartDate = trip.StartDate,
-                EndDate = trip.EndDate
-            },
-            cancellationToken).ConfigureAwait(false);
+                _dbContext.Entry(item).State = EntityState.Added;
+            }
+        }
 
         await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
@@ -49,7 +76,23 @@ public sealed class TripRepository : ITripRepository
     {
         var trip = await _dbContext.Trips
             .AsNoTracking()
+            .Include(model => model.Baggages)
+            .ThenInclude(model => model.Items)
             .SingleOrDefaultAsync(trip => trip.Id == tripId.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        return trip is null ? null : MapTrip(trip);
+    }
+
+    public async Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+    {
+        var trip = await _dbContext.Trips
+            .AsNoTracking()
+            .Include(model => model.Baggages)
+            .ThenInclude(model => model.Items)
+            .SingleOrDefaultAsync(
+                trip => trip.Baggages.Any(baggage => baggage.Items.Any(item => item.Id == itemId.Value)),
+                cancellationToken)
             .ConfigureAwait(false);
 
         return trip is null ? null : MapTrip(trip);
@@ -57,11 +100,66 @@ public sealed class TripRepository : ITripRepository
 
     private static TripEntity MapTrip(TripDataModel trip)
     {
-        return new TripEntity(
+        return TripEntity.Rehydrate(
             TripId.FromGuid(trip.Id),
             UserId.FromGuid(trip.OwnerId),
             trip.Destination,
             trip.StartDate,
-            trip.EndDate);
+            trip.EndDate,
+            trip.Baggages.Select(MapBaggage));
+    }
+
+    private static Baggage MapBaggage(BaggageDataModel baggage)
+    {
+        return Baggage.Rehydrate(
+            BaggageId.FromGuid(baggage.Id),
+            TripId.FromGuid(baggage.TripId),
+            baggage.Name,
+            baggage.IsDefaultBaggage,
+            baggage.Items.Select(MapItem));
+    }
+
+    private static Item MapItem(ItemDataModel item)
+    {
+        return Item.Rehydrate(
+            ItemId.FromGuid(item.Id),
+            TripId.FromGuid(item.TripId),
+            BaggageId.FromGuid(item.BaggageId),
+            item.Name,
+            item.CheckCount,
+            item.DefaultItemId);
+    }
+
+    private static TripDataModel MapTripDataModel(TripEntity trip)
+    {
+        return new TripDataModel
+        {
+            Id = trip.Id.Value,
+            OwnerId = trip.OwnerId.Value,
+            Destination = trip.Destination,
+            StartDate = trip.StartDate,
+            EndDate = trip.EndDate,
+            Baggages = MapBaggageDataModels(trip).ToList()
+        };
+    }
+
+    private static IEnumerable<BaggageDataModel> MapBaggageDataModels(TripEntity trip)
+    {
+        return trip.Baggages.Select(baggage => new BaggageDataModel
+        {
+            Id = baggage.Id.Value,
+            TripId = baggage.TripId.Value,
+            Name = baggage.Name,
+            IsDefaultBaggage = baggage.IsDefaultBaggage,
+            Items = baggage.Items.Select(item => new ItemDataModel
+            {
+                Id = item.Id.Value,
+                TripId = item.TripId.Value,
+                BaggageId = item.BaggageId.Value,
+                Name = item.Name,
+                CheckCount = item.CheckCount,
+                DefaultItemId = item.DefaultItemId
+            }).ToList()
+        });
     }
 }

--- a/src/Trip.API/Program.cs
+++ b/src/Trip.API/Program.cs
@@ -1,7 +1,12 @@
 using Microsoft.EntityFrameworkCore;
 using Trip.API.Api.ErrorHandling;
+using Trip.API.Api.Items;
 using Trip.API.Api.Trips;
 using Trip.API.Application.Abstractions;
+using Trip.API.Application.Items.CreateItemInTrip;
+using Trip.API.Application.Items.GetItem;
+using Trip.API.Application.Items.ListItemsByTrip;
+using Trip.API.Application.Items.PatchItem;
 using Trip.API.Application.Trips.CreateTrip;
 using Trip.API.Application.Trips.GetTripById;
 using Trip.API.Application.Trips.GetTrips;
@@ -25,6 +30,10 @@ builder.Services.AddScoped<IUserContextAccessor, HttpUserContextAccessor>();
 builder.Services.AddScoped<CreateTripHandler>();
 builder.Services.AddScoped<GetTripsHandler>();
 builder.Services.AddScoped<GetTripByIdHandler>();
+builder.Services.AddScoped<ListItemsByTripHandler>();
+builder.Services.AddScoped<CreateItemInTripHandler>();
+builder.Services.AddScoped<GetItemHandler>();
+builder.Services.AddScoped<PatchItemHandler>();
 
 var app = builder.Build();
 
@@ -38,6 +47,7 @@ app.UseExceptionHandler();
 app.UseHttpsRedirection();
 
 app.MapTripEndpoints();
+app.MapItemEndpoints();
 
 app.Run();
 

--- a/src/Trip.API/Trip.API.http
+++ b/src/Trip.API/Trip.API.http
@@ -1,6 +1,47 @@
 @Trip.API_HostAddress = http://localhost:5110
+@TestUserId = 11111111-1111-1111-1111-111111111111
+@TripId = 22222222-2222-2222-2222-222222222222
+@ItemId = 33333333-3333-3333-3333-333333333333
 
-GET {{Trip.API_HostAddress}}/weatherforecast/
+### Create trip
+POST {{Trip.API_HostAddress}}/trips
 Accept: application/json
+Content-Type: application/json
+X-Test-User-Id: {{TestUserId}}
 
-###
+{
+  "destination": "Vienna",
+  "startDate": "2026-06-01",
+  "endDate": "2026-06-04"
+}
+
+### List items by trip
+GET {{Trip.API_HostAddress}}/trips/{{TripId}}/items
+Accept: application/json
+X-Test-User-Id: {{TestUserId}}
+
+### Create item in trip
+POST {{Trip.API_HostAddress}}/trips/{{TripId}}/items
+Accept: application/json
+Content-Type: application/json
+X-Test-User-Id: {{TestUserId}}
+
+{
+  "name": "Passport",
+  "defaultItemId": null
+}
+
+### Get item
+GET {{Trip.API_HostAddress}}/items/{{ItemId}}
+Accept: application/json
+X-Test-User-Id: {{TestUserId}}
+
+### Patch item
+PATCH {{Trip.API_HostAddress}}/items/{{ItemId}}
+Accept: application/json
+Content-Type: application/json
+X-Test-User-Id: {{TestUserId}}
+
+{
+  "name": "Updated Passport"
+}

--- a/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Items/CreateItemInTripEndpointTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Items;
+
+public sealed class CreateItemInTripEndpointTests
+{
+    [Fact]
+    public async Task CreateItemInTrip_ReturnsCreated_WhenTripIsOwnedByCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Vienna");
+
+        var response = await client.PostAsJsonAsync($"/trips/{trip.Id}/items", new { name = "Passport" });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var item = await response.Content.ReadFromJsonAsync<ItemResponseContract>();
+        Assert.Equal(trip.Id, item!.TripId);
+        Assert.NotEqual(Guid.Empty, item.BaggageId);
+    }
+
+    [Fact]
+    public async Task CreateItemInTrip_ReturnsNotFound_WhenTripDoesNotExist()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.PostAsJsonAsync($"/trips/{Guid.NewGuid()}/items", new { name = "Passport" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateItemInTrip_ReturnsForbidden_WhenTripBelongsToDifferentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(ownerClient, "Berlin");
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await otherClient.PostAsJsonAsync($"/trips/{trip.Id}/items", new { name = "Passport" });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateItemInTrip_ReturnsBadRequest_WhenNameIsBlank()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Rome");
+
+        var response = await client.PostAsJsonAsync($"/trips/{trip.Id}/items", new { name = " " });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static async Task<TripResponseContract> CreateTripAsync(HttpClient client, string destination)
+    {
+        var response = await client.PostAsJsonAsync("/trips", new { destination });
+        return (await response.Content.ReadFromJsonAsync<TripResponseContract>())!;
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+    private sealed record ItemResponseContract(Guid Id, Guid TripId, Guid BaggageId, string Name, int CheckCount, Guid? DefaultItemId);
+}

--- a/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Items;
+
+public sealed class GetItemEndpointTests
+{
+    [Fact]
+    public async Task GetItem_ReturnsItem_WhenOwnedByCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Lisbon");
+        var item = await CreateItemAsync(client, trip.Id, "Passport");
+
+        var response = await client.GetAsync($"/items/{item.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetItem_ReturnsNotFound_WhenItemDoesNotExist()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.GetAsync($"/items/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetItem_ReturnsForbidden_WhenItemBelongsToDifferentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(ownerClient, "Oslo");
+        var item = await CreateItemAsync(ownerClient, trip.Id, "Passport");
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await otherClient.GetAsync($"/items/{item.Id}");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    private static async Task<TripResponseContract> CreateTripAsync(HttpClient client, string destination)
+    {
+        var response = await client.PostAsJsonAsync("/trips", new { destination });
+        return (await response.Content.ReadFromJsonAsync<TripResponseContract>())!;
+    }
+
+    private static async Task<ItemResponseContract> CreateItemAsync(HttpClient client, Guid tripId, string name)
+    {
+        var response = await client.PostAsJsonAsync($"/trips/{tripId}/items", new { name });
+        return (await response.Content.ReadFromJsonAsync<ItemResponseContract>())!;
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+    private sealed record ItemResponseContract(Guid Id, Guid TripId, Guid BaggageId, string Name, int CheckCount, Guid? DefaultItemId);
+}

--- a/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Items;
+
+public sealed class ListItemsByTripEndpointTests
+{
+    [Fact]
+    public async Task ListItemsByTrip_ReturnsItems_WhenTripIsOwnedByCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var trip = await CreateTripAsync(client, "Vienna");
+        await client.PostAsJsonAsync($"/trips/{trip.Id}/items", new { name = "Passport" });
+        await client.PostAsJsonAsync($"/trips/{trip.Id}/items", new { name = "Shoes" });
+
+        var response = await client.GetAsync($"/trips/{trip.Id}/items");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var items = await response.Content.ReadFromJsonAsync<ItemResponseContract[]>();
+        Assert.Equal(2, items!.Length);
+    }
+
+    [Fact]
+    public async Task ListItemsByTrip_ReturnsEmptyArray_WhenTripHasNoItems()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var trip = await CreateTripAsync(client, "Prague");
+
+        var response = await client.GetAsync($"/trips/{trip.Id}/items");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var items = await response.Content.ReadFromJsonAsync<ItemResponseContract[]>();
+        Assert.Empty(items!);
+    }
+
+    [Fact]
+    public async Task ListItemsByTrip_ReturnsNotFound_WhenTripDoesNotExist()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.GetAsync($"/trips/{Guid.NewGuid()}/items");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ListItemsByTrip_ReturnsForbidden_WhenTripBelongsToDifferentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(ownerClient, "Budapest");
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await otherClient.GetAsync($"/trips/{trip.Id}/items");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    private static async Task<TripResponseContract> CreateTripAsync(HttpClient client, string destination)
+    {
+        var response = await client.PostAsJsonAsync("/trips", new { destination });
+        return (await response.Content.ReadFromJsonAsync<TripResponseContract>())!;
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+    private sealed record ItemResponseContract(Guid Id, Guid TripId, Guid BaggageId, string Name, int CheckCount, Guid? DefaultItemId);
+}

--- a/tests/Trip.API.IntegrationTests/Items/PatchItemEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Items/PatchItemEndpointTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Items;
+
+public sealed class PatchItemEndpointTests
+{
+    [Fact]
+    public async Task PatchItem_ReturnsUpdatedItem_WhenOwnedByCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Helsinki");
+        var item = await CreateItemAsync(client, trip.Id, "Passport");
+
+        var response = await client.PatchAsJsonAsync($"/items/{item.Id}", new { name = "Updated Passport", defaultItemId = Guid.NewGuid() });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var updated = await response.Content.ReadFromJsonAsync<ItemResponseContract>();
+        Assert.Equal("Updated Passport", updated!.Name);
+    }
+
+    [Fact]
+    public async Task PatchItem_ReturnsNotFound_WhenItemDoesNotExist()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.PatchAsJsonAsync($"/items/{Guid.NewGuid()}", new { name = "Updated Passport" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PatchItem_ReturnsForbidden_WhenItemBelongsToDifferentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(ownerClient, "Tallinn");
+        var item = await CreateItemAsync(ownerClient, trip.Id, "Passport");
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await otherClient.PatchAsJsonAsync($"/items/{item.Id}", new { name = "Updated Passport" });
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PatchItem_ReturnsBadRequest_WhenNameIsBlank()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Copenhagen");
+        var item = await CreateItemAsync(client, trip.Id, "Passport");
+
+        var response = await client.PatchAsJsonAsync($"/items/{item.Id}", new { name = " " });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static async Task<TripResponseContract> CreateTripAsync(HttpClient client, string destination)
+    {
+        var response = await client.PostAsJsonAsync("/trips", new { destination });
+        return (await response.Content.ReadFromJsonAsync<TripResponseContract>())!;
+    }
+
+    private static async Task<ItemResponseContract> CreateItemAsync(HttpClient client, Guid tripId, string name)
+    {
+        var response = await client.PostAsJsonAsync($"/trips/{tripId}/items", new { name });
+        return (await response.Content.ReadFromJsonAsync<ItemResponseContract>())!;
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+    private sealed record ItemResponseContract(Guid Id, Guid TripId, Guid BaggageId, string Name, int CheckCount, Guid? DefaultItemId);
+}

--- a/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.CreateItemInTrip;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Items;
+
+public sealed class CreateItemInTripHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_CreatesItemInDefaultBaggage_WhenTripIsOwned()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var repository = new InMemoryTripRepository(trip);
+        var handler = new CreateItemInTripHandler(repository, NullLogger<CreateItemInTripHandler>.Instance);
+
+        var result = await handler.HandleAsync(
+            new CreateItemInTripCommand(trip.OwnerId, trip.Id, new NewItemDto("Passport", null)),
+            CancellationToken.None);
+
+        Assert.Equal("Passport", result.Item.Name);
+        Assert.True(repository.UpdateCalled);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsNotFound_WhenTripIsMissing()
+    {
+        var handler = new CreateItemInTripHandler(new InMemoryTripRepository(), NullLogger<CreateItemInTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => handler.HandleAsync(
+            new CreateItemInTripCommand(TripFixtures.CreateUserId(), TripId.CreateUnique(), new NewItemDto("Passport", null)),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsForbidden_WhenTripBelongsToDifferentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var handler = new CreateItemInTripHandler(new InMemoryTripRepository(trip), NullLogger<CreateItemInTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => handler.HandleAsync(
+            new CreateItemInTripCommand(TripFixtures.CreateUserId(), trip.Id, new NewItemDto("Passport", null)),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsValidationException_WhenNameIsBlank()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var handler = new CreateItemInTripHandler(new InMemoryTripRepository(trip), NullLogger<CreateItemInTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<ValidationException>(() => handler.HandleAsync(
+            new CreateItemInTripCommand(trip.OwnerId, trip.Id, new NewItemDto(" ", null)),
+            CancellationToken.None));
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        private readonly List<TripEntity> _trips;
+
+        public bool UpdateCalled { get; private set; }
+
+        public InMemoryTripRepository(params TripEntity[] trips)
+        {
+            _trips = trips.ToList();
+        }
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            UpdateCalled = true;
+            return Task.CompletedTask;
+        }
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+    }
+}

--- a/tests/Trip.API.UnitTests/Application/Items/GetItemHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/GetItemHandlerTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.GetItem;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Items;
+
+public sealed class GetItemHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_ReturnsItem_WhenOwnedByCurrentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var handler = new GetItemHandler(new InMemoryTripRepository(trip), NullLogger<GetItemHandler>.Instance);
+
+        var result = await handler.HandleAsync(new GetItemQuery(trip.OwnerId, item.Id), CancellationToken.None);
+
+        Assert.Equal(item.Id.Value, result.Item.Id);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsNotFound_WhenItemDoesNotExist()
+    {
+        var handler = new GetItemHandler(new InMemoryTripRepository(), NullLogger<GetItemHandler>.Instance);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => handler.HandleAsync(
+            new GetItemQuery(TripFixtures.CreateUserId(), ItemId.CreateUnique()),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsForbidden_WhenItemBelongsToDifferentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var handler = new GetItemHandler(new InMemoryTripRepository(trip), NullLogger<GetItemHandler>.Instance);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => handler.HandleAsync(
+            new GetItemQuery(TripFixtures.CreateUserId(), item.Id),
+            CancellationToken.None));
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        private readonly List<TripEntity> _trips;
+
+        public InMemoryTripRepository(params TripEntity[] trips)
+        {
+            _trips = trips.ToList();
+        }
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+    }
+}

--- a/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs
@@ -1,0 +1,70 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.ListItemsByTrip;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Items;
+
+public sealed class ListItemsByTripHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_ReturnsItems_WhenTripIsOwnedByCurrentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        trip.AddItemToDefaultBaggage("Passport");
+        trip.AddItemToDefaultBaggage("Shoes");
+
+        var handler = new ListItemsByTripHandler(new InMemoryTripRepository(trip), NullLogger<ListItemsByTripHandler>.Instance);
+
+        var result = await handler.HandleAsync(new ListItemsByTripQuery(trip.OwnerId, trip.Id), CancellationToken.None);
+
+        Assert.Equal(2, result.Items.Count);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsNotFound_WhenTripIsMissing()
+    {
+        var handler = new ListItemsByTripHandler(new InMemoryTripRepository(), NullLogger<ListItemsByTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => handler.HandleAsync(
+            new ListItemsByTripQuery(TripFixtures.CreateUserId(), TripId.CreateUnique()),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsForbidden_WhenTripBelongsToDifferentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var handler = new ListItemsByTripHandler(new InMemoryTripRepository(trip), NullLogger<ListItemsByTripHandler>.Instance);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => handler.HandleAsync(
+            new ListItemsByTripQuery(TripFixtures.CreateUserId(), trip.Id),
+            CancellationToken.None));
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        private readonly List<TripEntity> _trips;
+
+        public InMemoryTripRepository(params TripEntity[] trips)
+        {
+            _trips = trips.ToList();
+        }
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+    }
+}

--- a/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.PatchItem;
+using Trip.API.Domain.Entities;
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+using TripEntity = Trip.API.Domain.Entities.Trip;
+
+namespace Trip.API.UnitTests.Application.Items;
+
+public sealed class PatchItemHandlerTests
+{
+    [Fact]
+    public async Task HandleAsync_UpdatesAllowedFields_WhenOwnedByCurrentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var repository = new InMemoryTripRepository(trip);
+        var handler = new PatchItemHandler(repository, NullLogger<PatchItemHandler>.Instance);
+        var newDefaultItemId = Guid.NewGuid();
+
+        var result = await handler.HandleAsync(
+            new PatchItemCommand(trip.OwnerId, item.Id, new PatchItemDto("Updated Passport", true, newDefaultItemId, true)),
+            CancellationToken.None);
+
+        Assert.Equal("Updated Passport", result.Item.Name);
+        Assert.Equal(newDefaultItemId, result.Item.DefaultItemId);
+        Assert.True(repository.UpdateCalled);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsNotFound_WhenItemIsMissing()
+    {
+        var handler = new PatchItemHandler(new InMemoryTripRepository(), NullLogger<PatchItemHandler>.Instance);
+
+        await Assert.ThrowsAsync<NotFoundException>(() => handler.HandleAsync(
+            new PatchItemCommand(TripFixtures.CreateUserId(), ItemId.CreateUnique(), new PatchItemDto("Passport", true, null, false)),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsForbidden_WhenItemBelongsToDifferentUser()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var handler = new PatchItemHandler(new InMemoryTripRepository(trip), NullLogger<PatchItemHandler>.Instance);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() => handler.HandleAsync(
+            new PatchItemCommand(TripFixtures.CreateUserId(), item.Id, new PatchItemDto("Passport", true, null, false)),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_ThrowsValidationException_WhenNameIsBlank()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var handler = new PatchItemHandler(new InMemoryTripRepository(trip), NullLogger<PatchItemHandler>.Instance);
+
+        await Assert.ThrowsAsync<ValidationException>(() => handler.HandleAsync(
+            new PatchItemCommand(trip.OwnerId, item.Id, new PatchItemDto(" ", true, null, false)),
+            CancellationToken.None));
+    }
+
+    private sealed class InMemoryTripRepository : ITripRepository
+    {
+        private readonly List<TripEntity> _trips;
+
+        public bool UpdateCalled { get; private set; }
+
+        public InMemoryTripRepository(params TripEntity[] trips)
+        {
+            _trips = trips.ToList();
+        }
+
+        public Task AddAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            UpdateCalled = true;
+            return Task.CompletedTask;
+        }
+
+        public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
+
+        public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
+            => Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+    }
+}

--- a/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs
@@ -68,9 +68,19 @@ public sealed class CreateTripHandlerTests
             return Task.FromResult(Trips.SingleOrDefault(trip => trip.Id == tripId));
         }
 
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+        }
+
         public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<TripEntity>>(Trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+        }
+
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs
@@ -69,9 +69,19 @@ public sealed class GetTripByIdHandlerTests
             return Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
         }
 
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+        }
+
         public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+        }
+
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs
@@ -54,9 +54,19 @@ public sealed class GetTripsHandlerTests
             return Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));
         }
 
+        public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+        }
+
         public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());
+        }
+
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
         }
     }
 }

--- a/tests/Trip.API.UnitTests/Domain/ItemTests.cs
+++ b/tests/Trip.API.UnitTests/Domain/ItemTests.cs
@@ -1,0 +1,68 @@
+using Trip.API.Domain.ValueObjects;
+using Trip.API.UnitTests.Testing;
+
+namespace Trip.API.UnitTests.Domain;
+
+public sealed class ItemTests
+{
+    [Fact]
+    public void AddItemToDefaultBaggage_CreatesDefaultBaggage_WhenMissing()
+    {
+        var trip = TripFixtures.CreateTrip();
+
+        var item = trip.AddItemToDefaultBaggage("Passport");
+
+        var defaultBaggage = Assert.Single(trip.Baggages);
+        Assert.True(defaultBaggage.IsDefaultBaggage);
+        Assert.Equal(defaultBaggage.Id, item.BaggageId);
+        Assert.Equal(trip.Id, item.TripId);
+        Assert.Equal(0, item.CheckCount);
+    }
+
+    [Fact]
+    public void Rename_ThrowsArgumentException_WhenNameIsBlank()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+
+        Assert.Throws<ArgumentException>(() => item.Rename(" "));
+    }
+
+    [Fact]
+    public void UpdateDefaultItemId_UpdatesReference()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var defaultItemId = Guid.NewGuid();
+
+        item.UpdateDefaultItemId(defaultItemId);
+
+        Assert.Equal(defaultItemId, item.DefaultItemId);
+    }
+
+    [Fact]
+    public void FindItem_ReturnsItem_WhenPresentInTrip()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+
+        var found = trip.FindItem(item.Id);
+
+        Assert.NotNull(found);
+        Assert.Equal(item.Id, found!.Id);
+    }
+
+    [Fact]
+    public void Rehydrate_CreatesItemWithExistingCheckCount()
+    {
+        var item = Trip.API.Domain.Entities.Item.Rehydrate(
+            ItemId.CreateUnique(),
+            TripId.CreateUnique(),
+            BaggageId.CreateUnique(),
+            "Passport",
+            2,
+            Guid.NewGuid());
+
+        Assert.Equal(2, item.CheckCount);
+    }
+}

--- a/tests/Trip.API.UnitTests/Testing/TripFixtures.cs
+++ b/tests/Trip.API.UnitTests/Testing/TripFixtures.cs
@@ -33,4 +33,9 @@ public static class TripFixtures
             startDate,
             endDate);
     }
+
+    public static NewItemDto CreateNewItemDto(string name = "Passport", Guid? defaultItemId = null)
+    {
+        return new NewItemDto(name, defaultItemId);
+    }
 }


### PR DESCRIPTION
  ## Summary

  Implements the Items API slice for the travel service using the existing trip-owned aggregate boundary.

  This PR adds support for:
  - `GET /trips/{tripId}/items`
  - `POST /trips/{tripId}/items`
  - `GET /items/{itemId}`
  - `PATCH /items/{itemId}`

  Ownership is enforced on all four endpoints by resolving the authenticated user and verifying that the related trip
  belongs to that user. Trip-scoped item creation now reuses the trip's default baggage or creates it on demand if it
  does not exist.

  ## Scope

  Included:
  - Item DTOs, commands, queries, handlers, and endpoint implementations
  - Item endpoint naming aligned with OpenAPI `operationId` values
  - Persistence updates for nested `Trip -> Baggage -> Item` storage in EF Core InMemory
  - Domain updates to support item rehydration, lookup, rename, and default-baggage creation
  - Unit and integration coverage for happy paths and failure paths
  - HTTP example updates
  - Task tracker completion for `002-trip-items-api`

  Not included:
  - Item deletion
  - `checkItem`
  - Baggage-scoped item endpoints
  - Auth flow changes

  ## Key Design Decisions

  - Keep Items and Trips separate at the contract surface, but use the current trip-owned aggregate and persistence
  boundary for baggages and items.
  - Use repository abstractions rather than direct `DbContext` access from handlers.
  - Return typed failures through the existing problem details pipeline:
    - `400` for validation errors
    - `401` when the current user cannot be resolved
    - `403` for foreign trip/item access
    - `404` for missing trips/items

  ## Validation

  Executed successfully:
  - `dotnet build --no-incremental`
  - `dotnet test --no-build`
  - `dotnet format --verify-no-changes`

  ## Commits

  - `feat(shared): extend trip aggregate persistence for items`
  - `feat(item): add list and create item flows`
  - `feat(item): add get and patch item flows`
  - `chore(item): wire endpoints and update task tracker`

  ## Related Task

  - `002-trip-items-api`