### PR TITLE
003 item check counter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@
 - C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling (001-add-trip-api)
 - Entity Framework in-memory database for the current phase (001-add-trip-api)
 - Entity Framework in-memory database for the current phase, expanded to persist trips with related baggages and items (002-trip-items-api)
+- Entity Framework in-memory database for the current phase, persisting trips with owned baggages and items including `checkCount` (003-item-check-counter)
 
 ## Recent Changes
 - 001-add-trip-api: Added C# with .NET 10 (`net10.0`) + ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling

--- a/specs/003-item-check-counter/checklists/requirements.md
+++ b/specs/003-item-check-counter/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Item Check Counter
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-16
+**Feature**: [spec.md](/home/sicor/local-repos/maletapp/specs/003-item-check-counter/spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass completed after review against the generated spec.
+- The spec aligns with the existing item contract concept of a cumulative `checkCount` while staying implementation-agnostic.

--- a/specs/003-item-check-counter/contracts/items.md
+++ b/specs/003-item-check-counter/contracts/items.md
@@ -1,0 +1,40 @@
+# Items API Contract Summary
+
+Source of truth: [item.yml](/home/sicor/local-repos/maletapp/spec/item.yml)
+
+## Endpoint In Scope
+
+### `POST /items/{itemId}/check-item` (`checkItem`)
+
+- Purpose: Record one additional packing check for an existing owned item.
+- Path parameter:
+  - `itemId`: required UUID string identifying the item to check
+- Request body:
+  - No request body
+- Success response:
+  - `200 OK`
+  - Response body contains the updated item object with `id`, `tripId`, `baggageId`, `name`, `checkCount`, and optional `defaultItemId`
+- Failure outcomes:
+  - `400 Bad Request` for an invalid item identifier format or otherwise invalid request
+  - `401 Unauthorized` when no current user can be resolved
+  - `403 Forbidden` when the item belongs to a different user's trip
+  - `404 Not Found` when the item does not exist
+  - `500 Internal Server Error` for unexpected failures
+
+## Related Retrieval Contract Expectations
+
+- `GET /trips/{tripId}/items` and `GET /items/{itemId}` remain responsible for exposing the current `checkCount` value for each returned item.
+- `checkCount` is read-only from the client perspective and must not be set directly through create or patch requests.
+- A successful `checkItem` action changes only the `checkCount`; item identity, trip association, baggage association, name, and optional predefined-item reference remain unchanged.
+
+## Ownership Rules
+
+- The current user must be resolved before the check action is attempted.
+- The check action is allowed only when the target item's related trip belongs to the current user.
+- Requests for another user's item return `403 Forbidden`.
+
+## Response Shape Notes
+
+- `Item` responses include `id`, `tripId`, `baggageId`, `name`, `checkCount`, and optional `defaultItemId`.
+- `checkCount` is a cumulative counter of successful packing confirmations, not a boolean done flag.
+- The contract supports repeated checks of the same item so outbound and return packing history can be preserved.

--- a/specs/003-item-check-counter/data-model.md
+++ b/specs/003-item-check-counter/data-model.md
@@ -1,0 +1,97 @@
+# Data Model: Item Check Counter
+
+## Trip
+
+- Purpose: Represents the ownership boundary for all item operations, including the item check flow.
+- Fields:
+  - `Id`: Unique trip identifier.
+  - `OwnerId`: User identifier used to authorize access to the trip and its items.
+  - `Destination`: Required destination label.
+  - `StartDate`: Optional trip start date.
+  - `EndDate`: Optional trip end date.
+- Relationships:
+  - One trip belongs to one user.
+  - One trip can contain many baggages.
+  - One trip can contain many items through its baggages.
+- Validation rules:
+  - `Destination` is required and cannot be blank.
+  - If both dates are present, `StartDate` must be on or before `EndDate`.
+- State transitions relevant to this feature:
+  - Retrieved as the ownership source when a user checks an item.
+  - Unchanged by a successful check action other than reflecting the updated nested item count value.
+
+## Baggage
+
+- Purpose: Contains items within a trip and preserves the item's physical packing context.
+- Fields:
+  - `Id`: Unique baggage identifier.
+  - `TripId`: Identifier of the owning trip.
+  - `Name`: Baggage label.
+  - `IsDefaultBaggage`: Marks the trip's default baggage for item creation.
+- Relationships:
+  - One baggage belongs to one trip.
+  - One baggage can contain many items.
+- Validation rules:
+  - `Name` is required and cannot be blank.
+  - A baggage must remain associated with exactly one trip.
+- State transitions relevant to this feature:
+  - Unchanged by item check actions.
+  - Continues to be returned as the item's owning baggage reference.
+
+## Item
+
+- Purpose: Represents a packing-list entry that users can mark as packed multiple times across outbound and return packing passes.
+- Fields:
+  - `Id`: Unique item identifier.
+  - `TripId`: Identifier of the owning trip exposed in item responses.
+  - `BaggageId`: Identifier of the baggage that contains the item.
+  - `Name`: User-facing item name.
+  - `CheckCount`: Non-negative cumulative count of completed packing checks.
+  - `DefaultItemId`: Optional reference to a predefined item.
+- Relationships:
+  - One item belongs to one baggage.
+  - One item belongs to one trip through its baggage.
+- Validation rules:
+  - `Name` remains required and cannot be blank.
+  - `CheckCount` starts at `0` on creation.
+  - `CheckCount` may only increase by one per successful check action in this feature.
+  - `CheckCount` must never become negative.
+  - `DefaultItemId`, when present, must remain a valid identifier value.
+- State transitions:
+  - `Unchecked`: `CheckCount = 0`; item exists but has not been marked as packed.
+  - `Packed Once`: `CheckCount = 1`; item has been confirmed packed for one packing pass.
+  - `Packed Multiple Times`: `CheckCount >= 2`; item has been confirmed packed across repeated packing passes such as the return trip.
+  - Transition rule: each successful `checkItem` action moves the item from `n` to `n + 1` without changing `Id`, `TripId`, `BaggageId`, `Name`, or `DefaultItemId`.
+
+## Current User Context
+
+- Purpose: Represents the authenticated request user used to authorize access to the target item.
+- Fields:
+  - `UserId`: Unique identifier used to verify ownership through the related trip.
+- Relationships:
+  - One current-user context maps to zero or more owned trips.
+- Validation rules:
+  - Requests without a resolved current user are invalid for item check operations.
+
+## Request and Response Shapes
+
+### Check Item Input
+
+- Fields:
+  - None in the request body.
+- Validation rules:
+  - The path must contain a valid item identifier.
+  - The item must exist and belong to a trip owned by the current user.
+
+### Item Output
+
+- Fields:
+  - `Id`
+  - `TripId`
+  - `BaggageId`
+  - `Name`
+  - `CheckCount`
+  - `DefaultItemId`
+- Notes:
+  - `CheckCount` is system-controlled and visible after both check and retrieval operations.
+  - Ownership is enforced through the related trip and is not returned as a separate field.

--- a/specs/003-item-check-counter/plan.md
+++ b/specs/003-item-check-counter/plan.md
@@ -1,0 +1,86 @@
+# Implementation Plan: Item Check Counter
+
+**Branch**: `003-item-check-counter` | **Date**: 2026-03-16 | **Spec**: [spec.md](/home/sicor/local-repos/maletapp/specs/003-item-check-counter/spec.md)
+**Input**: Feature specification from `/specs/003-item-check-counter/spec.md`
+
+## Summary
+
+Implement the item packing-check workflow so an owned item can be marked as packed repeatedly through the existing item contract. The implementation will add the `checkItem` API slice to the current Minimal API service, increment the item's cumulative `checkCount` without changing other item fields, preserve trip-based ownership checks through the current-user accessor and repository boundary, and add unit plus integration coverage for successful and failing check flows as well as check count visibility in existing item retrieval endpoints.
+
+## Technical Context
+
+**Language/Version**: C# with .NET 10 (`net10.0`)  
+**Primary Dependencies**: ASP.NET Core Minimal API, Entity Framework Core, EF Core InMemory provider, OpenAPI/Swagger tooling  
+**Storage**: Entity Framework in-memory database for the current phase, persisting trips with owned baggages and items including `checkCount`  
+**Testing**: .NET test runner with unit tests for domain and application behavior plus integration tests for HTTP endpoint behavior, ownership rules, and persistence wiring  
+**Target Platform**: Linux-hosted ASP.NET Core web service  
+**Project Type**: Web service  
+**Performance Goals**: Support local development and automated verification of item check flows with immediate visible count updates in item retrieval responses  
+**Constraints**: Preserve Items/Trips contract separation, keep repository abstractions between application and persistence, propagate `CancellationToken` from endpoint to handler and repository, use typed exceptions and structured logging, keep public endpoint handler names equal to OpenAPI `operationId` values, preserve existing item fields during check actions, and keep warnings at zero  
+**Scale/Scope**: 1 new item endpoint (`POST /items/{itemId}/check-item`), updates to existing item retrieval outputs to keep `checkCount` visible, 1 owned item aggregate behavior change, and matching unit plus integration test coverage
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- `Contract-First Delivery`: Pass. The plan is derived from [spec.md](/home/sicor/local-repos/maletapp/specs/003-item-check-counter/spec.md) and aligns with the existing `checkItem` contract already defined in [item.yml](/home/sicor/local-repos/maletapp/spec/item.yml).
+- `Domain Separation`: Pass. The feature stays inside the Items contract surface while continuing to use trip ownership as the allowed containment boundary defined by the constitution.
+- `Repository and Persistence Discipline`: Pass. The implementation will extend the existing repository-based item access path and will not allow endpoint or handler code to bypass persistence abstractions.
+- `Testable by Default`: Pass. The plan includes unit tests for check-count domain and application rules plus integration tests for the `checkItem` endpoint and related retrieval behavior.
+- `Operational Consistency`: Pass. The design keeps Minimal API handlers, explicit cancellation propagation, structured problem details through typed failures, and zero-warning verification gates.
+
+Post-design re-check: Pass. The research, data model, contract summary, and quickstart keep the feature within the existing item contract, trip-ownership boundary, repository discipline, and dual-layer test expectations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-item-check-counter/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── items.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+└── Trip.API/
+    ├── Domain/
+    │   ├── Entities/
+    │   └── Value-objects/
+    ├── Application/
+    │   ├── Abstractions/
+    │   ├── Dtos/
+    │   ├── Exceptions/
+    │   ├── Items/
+    │   └── Trips/
+    ├── Infrastructure/
+    │   ├── Persistence/
+    │   │   └── Configurations/
+    │   ├── Repositories/
+    │   └── UserContext/
+    └── Api/
+        ├── ErrorHandling/
+        ├── Items/
+        └── Trips/
+
+tests/
+├── Trip.API.UnitTests/
+│   ├── Application/
+│   └── Domain/
+└── Trip.API.IntegrationTests/
+    ├── Infrastructure/
+    └── Items/
+```
+
+**Structure Decision**: Keep the single deployable API project under `src/Trip.API` and add the check-item behavior inside the existing `Domain`, `Application/Items`, `Api/Items`, and persistence layers. Keep unit and integration coverage in the existing split test projects under `tests/` so domain increment rules, ownership behavior, and HTTP contract conformance remain independently testable.
+
+## Complexity Tracking
+
+No constitutional violations or justified exceptions are required for this plan.

--- a/specs/003-item-check-counter/quickstart.md
+++ b/specs/003-item-check-counter/quickstart.md
@@ -1,0 +1,40 @@
+# Quickstart: Item Check Counter
+
+## Goal
+
+Implement the item check workflow so the current user can mark an owned item as packed, receive the updated item with an incremented `checkCount`, and continue to see that cumulative count in existing item retrieval endpoints.
+
+## Implementation Sequence
+
+1. Confirm the existing item contract and response model continue to expose `checkCount` on item list and single-item retrieval responses.
+2. Extend the item domain behavior so an item can record one additional packing check without changing any other item field.
+3. Add application command, result, and handler logic under `src/Trip.API/Application/Items/` for the `checkItem` flow, including current-user ownership enforcement and typed failure outcomes.
+4. Extend repository abstractions and implementations so the owned item can be loaded, updated, and saved through the existing persistence boundary.
+5. Add the `checkItem` Minimal API endpoint under `src/Trip.API/Api/Items/` with a public handler name matching the OpenAPI `operationId`.
+6. Keep cancellation propagation, structured logging, and existing problem-details exception mapping consistent with the rest of the API.
+7. Add unit tests for item increment behavior and application-level ownership or missing-item failures.
+8. Add integration tests for:
+   - successful item checking
+   - repeated checks accumulating count
+   - unauthorized requests
+   - forbidden requests for another user's item
+   - missing-item requests
+   - retrieval endpoints returning the latest `checkCount`
+
+## Verification
+
+1. Run `dotnet build --no-incremental`.
+2. Run `dotnet test --no-build`.
+3. Run `dotnet format --verify-no-changes`.
+4. Manually verify HTTP or Swagger flows for:
+   - checking an owned item once and receiving `checkCount = 1`
+   - checking the same owned item multiple times and receiving cumulative counts
+   - retrieving the checked item through existing list and single-item endpoints
+   - receiving `403 Forbidden` for another user's item
+   - receiving clear failures for invalid identifiers, missing user context, and missing items
+
+## Notes
+
+- Keep the feature limited to the `checkItem` route plus existing response visibility of `checkCount`.
+- Do not introduce a boolean packed flag or a client-supplied counter update path.
+- Preserve the repository boundary even if the persistence layer needs small extensions to support the new mutation flow.

--- a/specs/003-item-check-counter/research.md
+++ b/specs/003-item-check-counter/research.md
@@ -1,0 +1,31 @@
+# Research: Item Check Counter
+
+## Decision 1: Model the packing action as an increment-only item behavior
+
+- Decision: Treat each check action as one additional packing confirmation that increments `checkCount` by exactly 1.
+- Rationale: The feature specification and item contract both define packing progress as a cumulative counter rather than a boolean status, and the return-trip use case depends on preserving prior packing history.
+- Alternatives considered: A boolean checked flag was rejected because it cannot represent multiple packing passes. A client-supplied counter value was rejected because it would allow overwriting history instead of recording a new check event.
+
+## Decision 2: Reuse the existing item retrieval contract instead of introducing a new progress view
+
+- Decision: Keep `checkCount` in the existing item response shape for list and single-item retrieval and rely on those views to communicate packing progress after check actions.
+- Rationale: The current item contract already exposes `checkCount` as part of `Item`, so the feature can stay contract-first without creating a separate progress resource or alternate response model.
+- Alternatives considered: A separate progress endpoint was rejected because it would duplicate data already present on the item contract. Returning only a success code from the check action was rejected because the feature requires users to see the updated count immediately.
+
+## Decision 3: Keep ownership and authorization anchored to the item's owning trip
+
+- Decision: Authorize `checkItem` through the same trip ownership rules already used for other item endpoints.
+- Rationale: The constitution allows item behavior to share the trip-owned aggregate boundary, and existing item operations already rely on the current-user accessor plus trip ownership to determine access.
+- Alternatives considered: A standalone item ownership rule was rejected because it would duplicate the current ownership model. Skipping authorization for check actions was rejected because it would break consistency with the rest of the item API.
+
+## Decision 4: Implement the check flow through existing repository and persistence paths
+
+- Decision: Extend the current repository-backed item update flow to load the owned item, increment `checkCount`, and persist the updated aggregate.
+- Rationale: The constitution requires repository abstractions rather than direct persistence access from handlers, and the current service already uses a repository-backed trip aggregate for item operations.
+- Alternatives considered: Direct `DbContext` access from the endpoint or handler was rejected because it would bypass repository discipline. A separate write-only persistence path for checks was rejected because it would split item mutation behavior across multiple infrastructure patterns.
+
+## Decision 5: Cover the feature with both domain/application and HTTP-level tests
+
+- Decision: Add unit tests for increment and ownership-related rules plus integration tests for successful, unauthorized, forbidden, and missing-item check flows.
+- Rationale: The constitution requires unit and integration coverage, and this feature has both business rules (`checkCount` increments, item immutability outside the counter) and externally visible API behavior (`checkItem` route and updated response content).
+- Alternatives considered: Unit tests only were rejected because they would not verify routing, serialization, and exception mapping. Integration tests only were rejected because they would make the core increment rule slower to isolate when it fails.

--- a/specs/003-item-check-counter/spec.md
+++ b/specs/003-item-check-counter/spec.md
@@ -1,0 +1,92 @@
+# Feature Specification: Item Check Counter
+
+**Feature Branch**: `003-item-check-counter`  
+**Created**: 2026-03-16  
+**Status**: Draft  
+**Input**: User description: "Users should be able to check the items as saved in the baggage for the trip, like a ToDo Task done. The check is not boolean is a counter because maybe you are going to need to save again the item when you want to come back to origin. review spec/item.yml to follow the api contract."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Mark an item as packed (Priority: P1)
+
+As a traveler preparing baggage for a trip, I want to mark an item as packed so I can track what has already been saved into the baggage without removing it from the packing list.
+
+**Why this priority**: This is the core outcome requested by the feature and enables the basic trip-packing workflow.
+
+**Independent Test**: Can be fully tested by checking an existing trip item once and confirming the returned item shows the updated packing progress.
+
+**Acceptance Scenarios**:
+
+1. **Given** an item belongs to a trip baggage and has not yet been checked, **When** the traveler checks the item as packed, **Then** the system increases the item's check count by 1 and returns the updated item details.
+2. **Given** an item already has a positive check count, **When** the traveler checks the item again, **Then** the system increases the check count by 1 instead of blocking the action or replacing the existing count.
+
+---
+
+### User Story 2 - Re-pack for a return trip (Priority: P2)
+
+As a traveler preparing to return to the origin, I want to check the same item again on a later packing pass so I can use the same item list for outbound and return packing.
+
+**Why this priority**: The request explicitly states that the checked state must be cumulative because items may need to be packed again for the return trip.
+
+**Independent Test**: Can be tested by checking the same item across multiple packing passes and confirming the total count preserves the full history of packing confirmations.
+
+**Acceptance Scenarios**:
+
+1. **Given** a traveler is reusing an existing trip item list for the return journey, **When** the traveler checks an item that was already packed earlier in the trip, **Then** the system records an additional check rather than resetting or overwriting the earlier count.
+2. **Given** a traveler views trip items after multiple checks, **When** the item list is retrieved, **Then** each item displays its current check count so the traveler can see how many times it has been marked as packed.
+
+---
+
+### User Story 3 - Protect item integrity during check actions (Priority: P3)
+
+As a traveler managing a trip list, I want check actions to affect only packing progress so that item identity and trip association remain unchanged.
+
+**Why this priority**: The check action should be safe and narrow in scope, preventing accidental edits to item details while users are updating packing progress.
+
+**Independent Test**: Can be tested by checking an item and verifying only the check count changes while the item name and trip or baggage association remain the same.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing item with a name and trip association, **When** the traveler performs a check action, **Then** the system preserves the item's name, trip, baggage, and any default item reference while updating only the check count.
+2. **Given** a traveler attempts to check an item that does not exist, **When** the action is submitted, **Then** the system rejects the request with a not found outcome and does not alter any other items.
+
+### Edge Cases
+
+- A check action against a non-existent item must fail without creating a new item or changing any other item.
+- Repeated checks submitted one after another must accumulate as separate increments.
+- Items with a check count of `0` must still appear in item retrieval results as valid unpacked items.
+- A check action must not allow the check count to become negative or be replaced with a boolean-style done state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow users to record a packing check for an existing item associated with a trip.
+- **FR-002**: The system MUST represent packing progress as a non-negative count of completed checks for each item, not as a boolean done or not-done value.
+- **FR-003**: When a user records a packing check, the system MUST increase the item's check count by exactly 1.
+- **FR-004**: The system MUST preserve the item's existing identity, trip association, baggage association, name, and predefined-item reference when a packing check is recorded.
+- **FR-005**: The system MUST return the updated item details immediately after a successful packing check, including the new check count.
+- **FR-006**: The system MUST expose each item's current check count whenever items are retrieved in trip or single-item views.
+- **FR-007**: The system MUST support multiple packing checks for the same item over time so the same item list can be reused for outbound and return packing.
+- **FR-008**: The system MUST reject attempts to record a packing check for an item that does not exist.
+- **FR-009**: The system MUST ensure a packing check never reduces the recorded check count.
+
+### Key Entities *(include if feature involves data)*
+
+- **Item**: A trip packing-list entry that belongs to a trip and optionally a baggage; key attributes include item identity, display name, trip reference, baggage reference, optional predefined-item reference, and packing check count.
+- **Packing Check Count**: The cumulative number of times an item has been marked as packed; it communicates packing progress across one or more packing passes for the same trip.
+
+## Assumptions
+
+- A single check action always represents one completed packing confirmation for one item.
+- Users can infer whether an item is currently unpacked by a check count of `0`.
+- The same item list is intentionally reused across the full trip lifecycle, including return packing.
+- Concurrent duplicate submissions are out of scope for this feature phase; users are assumed to submit check actions sequentially.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of successful check actions increase the selected item's displayed check count by exactly 1.
+- **SC-002**: 100% of item detail views and item list views show the current check count for each returned item.
+- **SC-003**: In end-to-end acceptance testing, users can complete an outbound packing pass and a return packing pass with the same item list without losing prior packing history.

--- a/specs/003-item-check-counter/tasks.md
+++ b/specs/003-item-check-counter/tasks.md
@@ -17,8 +17,8 @@
 
 **Purpose**: Prepare the solution for the new item check workflow
 
-- [ ] T001 Create the `CheckItem` application folder and scaffold files in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs`
-- [ ] T002 [P] Create the endpoint and test scaffold files for item checking in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
+- [X] T001 Create the `CheckItem` application folder and scaffold files in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs`
+- [X] T002 [P] Create the endpoint and test scaffold files for item checking in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
 
 ---
 
@@ -28,10 +28,10 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T003 Extend the item repository contract for owned-item check operations in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`
-- [ ] T004 [P] Add check-item endpoint naming, routing, and logging constants in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointNames.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemLogMessages.cs`
-- [ ] T005 [P] Register the check-item handler and endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
-- [ ] T006 Implement repository persistence support for loading and saving checked items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [X] T003 Extend the item repository contract for owned-item check operations in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`
+- [X] T004 [P] Add check-item endpoint naming, routing, and logging constants in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointNames.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemLogMessages.cs`
+- [X] T005 [P] Register the check-item handler and endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
+- [X] T006 Implement repository persistence support for loading and saving checked items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
 
 **Checkpoint**: Foundation ready - user story implementation can now begin
 
@@ -45,16 +45,16 @@
 
 ### Tests for User Story 1
 
-- [ ] T007 [P] [US1] Add item increment domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
-- [ ] T008 [P] [US1] Add check-item application unit tests covering owned-item success and unauthorized access in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
-- [ ] T009 [P] [US1] Add check-item integration tests covering successful first-time packing and unauthorized requests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
+- [X] T007 [P] [US1] Add item increment domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [X] T008 [P] [US1] Add check-item application unit tests covering owned-item success and unauthorized access in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
+- [X] T009 [P] [US1] Add check-item integration tests covering successful first-time packing and unauthorized requests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Implement increment-only item behavior in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs`
-- [ ] T011 [US1] Implement the check-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs`
-- [ ] T012 [US1] Implement check-item application logic with current-user resolution and ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs`
-- [ ] T013 [US1] Implement the `checkItem` endpoint with exact OpenAPI naming, cancellation propagation, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`
+- [X] T010 [US1] Implement increment-only item behavior in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs`
+- [X] T011 [US1] Implement the check-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs`
+- [X] T012 [US1] Implement check-item application logic with current-user resolution and ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs`
+- [X] T013 [US1] Implement the `checkItem` endpoint with exact OpenAPI naming, cancellation propagation, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`
 
 **Checkpoint**: User Story 1 should be fully functional and testable independently
 
@@ -68,14 +68,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T014 [P] [US2] Add repeated-check domain tests for cumulative packing history in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
-- [ ] T015 [P] [US2] Add repeated-check application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
-- [ ] T016 [P] [US2] Add repeated-check and retrieval-visibility integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`, `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
+- [X] T014 [P] [US2] Add repeated-check domain tests for cumulative packing history in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [X] T015 [P] [US2] Add repeated-check application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
+- [X] T016 [P] [US2] Add repeated-check and retrieval-visibility integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`, `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
 
 ### Implementation for User Story 2
 
-- [ ] T017 [US2] Preserve cumulative `checkCount` mapping across persistence reads and writes in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs`
-- [ ] T018 [US2] Ensure item response mapping continues exposing the latest `checkCount` in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
+- [X] T017 [US2] Preserve cumulative `checkCount` mapping across persistence reads and writes in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs`
+- [X] T018 [US2] Ensure item response mapping continues exposing the latest `checkCount` in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
 
 **Checkpoint**: User Stories 1 and 2 should both work independently
 
@@ -89,14 +89,14 @@
 
 ### Tests for User Story 3
 
-- [ ] T019 [P] [US3] Add item integrity domain tests to confirm check actions do not mutate non-counter fields in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
-- [ ] T020 [P] [US3] Add missing-item and foreign-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
-- [ ] T021 [P] [US3] Add missing-item, forbidden-item, and field-integrity integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
+- [X] T019 [P] [US3] Add item integrity domain tests to confirm check actions do not mutate non-counter fields in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [X] T020 [P] [US3] Add missing-item and foreign-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
+- [X] T021 [P] [US3] Add missing-item, forbidden-item, and field-integrity integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Enforce not-found and forbidden check-item outcomes through repository lookup and typed exceptions in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
-- [ ] T023 [US3] Preserve immutable item fields during check actions in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`
+- [X] T022 [US3] Enforce not-found and forbidden check-item outcomes through repository lookup and typed exceptions in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [X] T023 [US3] Preserve immutable item fields during check actions in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`
 
 **Checkpoint**: All user stories should now be independently functional
 
@@ -106,8 +106,8 @@
 
 **Purpose**: Final cross-story cleanup and verification
 
-- [ ] T024 [P] Update item-check examples and manual verification requests in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.http` and `/home/sicor/local-repos/maletapp/specs/003-item-check-counter/quickstart.md`
-- [ ] T025 Run the full verification flow documented in `/home/sicor/local-repos/maletapp/specs/003-item-check-counter/quickstart.md` with `dotnet build --no-incremental`, `dotnet test --no-build`, and `dotnet format --verify-no-changes`
+- [X] T024 [P] Update item-check examples and manual verification requests in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.http` and `/home/sicor/local-repos/maletapp/specs/003-item-check-counter/quickstart.md`
+- [X] T025 Run the full verification flow documented in `/home/sicor/local-repos/maletapp/specs/003-item-check-counter/quickstart.md` with `dotnet build --no-incremental`, `dotnet test --no-build`, and `dotnet format --verify-no-changes`
 
 ---
 

--- a/specs/003-item-check-counter/tasks.md
+++ b/specs/003-item-check-counter/tasks.md
@@ -1,0 +1,206 @@
+# Tasks: Item Check Counter
+
+**Input**: Design documents from `/specs/003-item-check-counter/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Unit and integration tests are required for this feature by the constitution and quickstart.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the solution for the new item check workflow
+
+- [ ] T001 Create the `CheckItem` application folder and scaffold files in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs`
+- [ ] T002 [P] Create the endpoint and test scaffold files for item checking in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`, `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core infrastructure that MUST be complete before any user story can be implemented
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Extend the item repository contract for owned-item check operations in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Abstractions/ITripRepository.cs`
+- [ ] T004 [P] Add check-item endpoint naming, routing, and logging constants in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointNames.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemLogMessages.cs`
+- [ ] T005 [P] Register the check-item handler and endpoint wiring in `/home/sicor/local-repos/maletapp/src/Trip.API/Program.cs`
+- [ ] T006 Implement repository persistence support for loading and saving checked items in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin
+
+---
+
+## Phase 3: User Story 1 - Mark an item as packed (Priority: P1) 🎯 MVP
+
+**Goal**: Let the current user mark one owned item as packed and immediately receive the updated item with `checkCount` increased by 1
+
+**Independent Test**: Check an owned item through `POST /items/{itemId}/check-item` and verify the response returns the same item identity with `checkCount` increased from `0` to `1`
+
+### Tests for User Story 1
+
+- [ ] T007 [P] [US1] Add item increment domain tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [ ] T008 [P] [US1] Add check-item application unit tests covering owned-item success and unauthorized access in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
+- [ ] T009 [P] [US1] Add check-item integration tests covering successful first-time packing and unauthorized requests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Implement increment-only item behavior in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs`
+- [ ] T011 [US1] Implement the check-item command and result models in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs`
+- [ ] T012 [US1] Implement check-item application logic with current-user resolution and ownership enforcement in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs`
+- [ ] T013 [US1] Implement the `checkItem` endpoint with exact OpenAPI naming, cancellation propagation, and structured logging in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`
+
+**Checkpoint**: User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Re-pack for a return trip (Priority: P2)
+
+**Goal**: Allow repeated checks of the same owned item so packing history accumulates across outbound and return packing passes
+
+**Independent Test**: Check the same owned item multiple times and verify `checkCount` increases cumulatively in the check response and in existing item retrieval endpoints
+
+### Tests for User Story 2
+
+- [ ] T014 [P] [US2] Add repeated-check domain tests for cumulative packing history in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [ ] T015 [P] [US2] Add repeated-check application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
+- [ ] T016 [P] [US2] Add repeated-check and retrieval-visibility integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`, `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs`, and `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs`
+
+### Implementation for User Story 2
+
+- [ ] T017 [US2] Preserve cumulative `checkCount` mapping across persistence reads and writes in `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Persistence/ItemDataModel.cs`
+- [ ] T018 [US2] Ensure item response mapping continues exposing the latest `checkCount` in `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/ItemResponse.cs`, `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/GetItem/GetItemHandler.cs`, and `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/ListItemsByTrip/ListItemsByTripHandler.cs`
+
+**Checkpoint**: User Stories 1 and 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - Protect item integrity during check actions (Priority: P3)
+
+**Goal**: Ensure check actions change only packing progress and return correct failure outcomes for missing or forbidden items
+
+**Independent Test**: Check a missing or foreign item and verify the correct failure response, then check an owned item and confirm `name`, `tripId`, `baggageId`, and `defaultItemId` remain unchanged while only `checkCount` increments
+
+### Tests for User Story 3
+
+- [ ] T019 [P] [US3] Add item integrity domain tests to confirm check actions do not mutate non-counter fields in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs`
+- [ ] T020 [P] [US3] Add missing-item and foreign-item application unit tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs`
+- [ ] T021 [P] [US3] Add missing-item, forbidden-item, and field-integrity integration tests in `/home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs`
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Enforce not-found and forbidden check-item outcomes through repository lookup and typed exceptions in `/home/sicor/local-repos/maletapp/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Infrastructure/Repositories/TripRepository.cs`
+- [ ] T023 [US3] Preserve immutable item fields during check actions in `/home/sicor/local-repos/maletapp/src/Trip.API/Domain/Entities/Item.cs` and `/home/sicor/local-repos/maletapp/src/Trip.API/Api/Items/CheckItemEndpoint.cs`
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cross-story cleanup and verification
+
+- [ ] T024 [P] Update item-check examples and manual verification requests in `/home/sicor/local-repos/maletapp/src/Trip.API/Trip.API.http` and `/home/sicor/local-repos/maletapp/specs/003-item-check-counter/quickstart.md`
+- [ ] T025 Run the full verification flow documented in `/home/sicor/local-repos/maletapp/specs/003-item-check-counter/quickstart.md` with `dotnet build --no-incremental`, `dotnet test --no-build`, and `dotnet format --verify-no-changes`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion; blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion; is the MVP
+- **User Story 2 (Phase 4)**: Depends on Foundational completion; reuses the same check-item flow but remains independently testable
+- **User Story 3 (Phase 5)**: Depends on Foundational completion; reuses the same check-item flow but remains independently testable
+- **Polish (Phase 6)**: Depends on all implemented user stories
+
+### User Story Dependencies
+
+- **US1**: No dependency on other user stories
+- **US2**: No strict dependency on other user stories after Foundational completion
+- **US3**: No strict dependency on other user stories after Foundational completion
+
+### Within Each User Story
+
+- Tests should be written before the corresponding implementation tasks
+- Domain behavior before handler behavior
+- Handler behavior before endpoint completion
+- Story verification after endpoint and persistence updates are complete
+
+### Parallel Opportunities
+
+- T002 can run in parallel with T001 after the feature scaffolding starts
+- T004 and T005 can run in parallel after T003
+- In US1, T007, T008, and T009 can run in parallel before T010 through T013
+- In US2, T014, T015, and T016 can run in parallel before T017 and T018
+- In US3, T019, T020, and T021 can run in parallel before T022 and T023
+- T024 can run in parallel with late-stage validation prep before T025
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Add item increment domain tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs"
+Task: "Add check-item application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs"
+Task: "Add check-item integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+Task: "Add repeated-check domain tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs"
+Task: "Add repeated-check application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs"
+Task: "Add repeated-check and retrieval-visibility integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs, /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/GetItemEndpointTests.cs, and /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/ListItemsByTripEndpointTests.cs"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+Task: "Add item integrity domain tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Domain/ItemTests.cs"
+Task: "Add missing-item and foreign-item application unit tests in /home/sicor/local-repos/maletapp/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs"
+Task: "Add missing-item, forbidden-item, and field-integrity integration tests in /home/sicor/local-repos/maletapp/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate the single check flow independently
+5. Commit the completed task work before moving to the next story
+
+### Incremental Delivery
+
+1. Complete Setup and Foundational work once
+2. Deliver US1 as the MVP
+3. Deliver US2 to add repeated packing support and retrieval visibility
+4. Deliver US3 to lock down integrity and failure handling
+5. Finish with cross-cutting verification and manual examples
+
+### Parallel Team Strategy
+
+1. One engineer can prepare repository contract changes while another wires endpoint constants and registration during Phase 2
+2. After Phase 2, one engineer can drive US1 while another prepares US2 retrieval-visibility tests
+3. Once US1 lands, US2 and US3 can be completed in parallel if the team avoids overlapping edits to the same files
+
+---
+
+## Notes
+
+- Every task follows the required checklist format with an ID, optional parallel marker, required story label for story work, and exact file paths
+- Tests are intentionally included because the feature plan and repository constitution require automated validation
+- US1 is the suggested MVP scope
+- Commit after each completed task or tight logical batch per repository guidance

--- a/src/Trip.API/Api/Items/CheckItemEndpoint.cs
+++ b/src/Trip.API/Api/Items/CheckItemEndpoint.cs
@@ -1,0 +1,45 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Exceptions;
+using Trip.API.Application.Items.CheckItem;
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Api.Items;
+
+public static class CheckItemEndpoint
+{
+    public static IEndpointRouteBuilder MapCheckItem(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost(
+                "/items/{itemId:guid}/check-item",
+                async Task<IResult> (
+                    Guid itemId,
+                    IUserContextAccessor userContextAccessor,
+                    CheckItemHandler handler,
+                    ILoggerFactory loggerFactory,
+                    CancellationToken cancellationToken) =>
+                {
+                    var userId = userContextAccessor.GetCurrentUserId()
+                        ?? throw new UnauthorizedException("Current user could not be determined.");
+
+                    var logger = loggerFactory.CreateLogger(nameof(CheckItemEndpoint));
+                    logger.CheckItemRequestReceived(userId.Value, itemId);
+
+                    var result = await handler.HandleAsync(
+                        new CheckItemCommand(userId, ItemId.FromGuid(itemId)),
+                        cancellationToken);
+
+                    var item = result.Item;
+                    return Results.Ok(new ItemResponse(
+                        item.Id,
+                        item.TripId,
+                        item.BaggageId,
+                        item.Name,
+                        item.CheckCount,
+                        item.DefaultItemId));
+                })
+            .WithName(ItemEndpointNames.CheckItem)
+            .WithTags("Items");
+
+        return endpoints;
+    }
+}

--- a/src/Trip.API/Api/Items/ItemEndpointNames.cs
+++ b/src/Trip.API/Api/Items/ItemEndpointNames.cs
@@ -6,4 +6,5 @@ public static class ItemEndpointNames
     public const string CreateItemInTrip = "createItemInTrip";
     public const string GetItem = "getItem";
     public const string PatchItem = "patchItem";
+    public const string CheckItem = "checkItem";
 }

--- a/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs
+++ b/src/Trip.API/Api/Items/ItemEndpointRouteBuilderExtensions.cs
@@ -8,6 +8,7 @@ public static class ItemEndpointRouteBuilderExtensions
         endpoints.MapCreateItemInTrip();
         endpoints.MapGetItem();
         endpoints.MapPatchItem();
+        endpoints.MapCheckItem();
 
         return endpoints;
     }

--- a/src/Trip.API/Api/Items/ItemLogMessages.cs
+++ b/src/Trip.API/Api/Items/ItemLogMessages.cs
@@ -13,4 +13,7 @@ internal static partial class ItemLogMessages
 
     [LoggerMessage(EventId = 1103, Level = LogLevel.Information, Message = "Received patch item request for user {UserId} and item {ItemId}")]
     public static partial void PatchItemRequestReceived(this ILogger logger, Guid userId, Guid itemId);
+
+    [LoggerMessage(EventId = 1104, Level = LogLevel.Information, Message = "Received check item request for user {UserId} and item {ItemId}")]
+    public static partial void CheckItemRequestReceived(this ILogger logger, Guid userId, Guid itemId);
 }

--- a/src/Trip.API/Application/Abstractions/ITripRepository.cs
+++ b/src/Trip.API/Application/Abstractions/ITripRepository.cs
@@ -15,4 +15,6 @@ public interface ITripRepository
     Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken);
 
     Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken);
+
+    Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken);
 }

--- a/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs
+++ b/src/Trip.API/Application/Items/CheckItem/CheckItemCommand.cs
@@ -1,0 +1,5 @@
+using Trip.API.Domain.ValueObjects;
+
+namespace Trip.API.Application.Items.CheckItem;
+
+public sealed record CheckItemCommand(UserId UserId, ItemId ItemId);

--- a/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs
+++ b/src/Trip.API/Application/Items/CheckItem/CheckItemHandler.cs
@@ -1,0 +1,49 @@
+using Trip.API.Application.Abstractions;
+using Trip.API.Application.Dtos;
+using Trip.API.Application.Exceptions;
+
+namespace Trip.API.Application.Items.CheckItem;
+
+public sealed class CheckItemHandler
+{
+    private readonly ILogger<CheckItemHandler> _logger;
+    private readonly ITripRepository _tripRepository;
+
+    public CheckItemHandler(ITripRepository tripRepository, ILogger<CheckItemHandler> logger)
+    {
+        _tripRepository = tripRepository;
+        _logger = logger;
+    }
+
+    public async Task<CheckItemResult> HandleAsync(CheckItemCommand command, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Checking item {ItemId} for user {UserId}", command.ItemId.Value, command.UserId.Value);
+
+        var trip = await _tripRepository.GetTripByItemIdForUpdateAsync(command.ItemId, cancellationToken).ConfigureAwait(false);
+
+        if (trip is null)
+        {
+            throw new NotFoundException($"Item {command.ItemId.Value} was not found.");
+        }
+
+        if (trip.OwnerId != command.UserId)
+        {
+            throw new ForbiddenException($"Item {command.ItemId.Value} is not accessible for the current user.");
+        }
+
+        var item = trip.FindItem(command.ItemId)
+            ?? throw new NotFoundException($"Item {command.ItemId.Value} was not found.");
+
+        item.Check();
+
+        await _tripRepository.UpdateAsync(trip, cancellationToken).ConfigureAwait(false);
+
+        return new CheckItemResult(new ItemDto(
+            item.Id.Value,
+            item.TripId.Value,
+            item.BaggageId.Value,
+            item.Name,
+            item.CheckCount,
+            item.DefaultItemId));
+    }
+}

--- a/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs
+++ b/src/Trip.API/Application/Items/CheckItem/CheckItemResult.cs
@@ -1,0 +1,5 @@
+using Trip.API.Application.Dtos;
+
+namespace Trip.API.Application.Items.CheckItem;
+
+public sealed record CheckItemResult(ItemDto Item);

--- a/src/Trip.API/Infrastructure/Repositories/TripRepository.cs
+++ b/src/Trip.API/Infrastructure/Repositories/TripRepository.cs
@@ -86,16 +86,33 @@ public sealed class TripRepository : ITripRepository
 
     public async Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
     {
-        var trip = await _dbContext.Trips
-            .AsNoTracking()
-            .Include(model => model.Baggages)
-            .ThenInclude(model => model.Items)
-            .SingleOrDefaultAsync(
-                trip => trip.Baggages.Any(baggage => baggage.Items.Any(item => item.Id == itemId.Value)),
-                cancellationToken)
-            .ConfigureAwait(false);
+        var trip = await GetTripByItemIdInternalAsync(itemId, asNoTracking: true, cancellationToken).ConfigureAwait(false);
 
         return trip is null ? null : MapTrip(trip);
+    }
+
+    public async Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+    {
+        var trip = await GetTripByItemIdInternalAsync(itemId, asNoTracking: true, cancellationToken).ConfigureAwait(false);
+
+        return trip is null ? null : MapTrip(trip);
+    }
+
+    private async Task<TripDataModel?> GetTripByItemIdInternalAsync(ItemId itemId, bool asNoTracking, CancellationToken cancellationToken)
+    {
+        var query = _dbContext.Trips
+            .Include(model => model.Baggages)
+            .ThenInclude(model => model.Items)
+            .Where(trip => trip.Baggages.Any(baggage => baggage.Items.Any(item => item.Id == itemId.Value)));
+
+        if (asNoTracking)
+        {
+            query = query.AsNoTracking();
+        }
+
+        return await query
+            .SingleOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static TripEntity MapTrip(TripDataModel trip)

--- a/src/Trip.API/Program.cs
+++ b/src/Trip.API/Program.cs
@@ -3,6 +3,7 @@ using Trip.API.Api.ErrorHandling;
 using Trip.API.Api.Items;
 using Trip.API.Api.Trips;
 using Trip.API.Application.Abstractions;
+using Trip.API.Application.Items.CheckItem;
 using Trip.API.Application.Items.CreateItemInTrip;
 using Trip.API.Application.Items.GetItem;
 using Trip.API.Application.Items.ListItemsByTrip;
@@ -32,6 +33,7 @@ builder.Services.AddScoped<GetTripsHandler>();
 builder.Services.AddScoped<GetTripByIdHandler>();
 builder.Services.AddScoped<ListItemsByTripHandler>();
 builder.Services.AddScoped<CreateItemInTripHandler>();
+builder.Services.AddScoped<CheckItemHandler>();
 builder.Services.AddScoped<GetItemHandler>();
 builder.Services.AddScoped<PatchItemHandler>();
 

--- a/src/Trip.API/Trip.API.http
+++ b/src/Trip.API/Trip.API.http
@@ -36,6 +36,11 @@ GET {{Trip.API_HostAddress}}/items/{{ItemId}}
 Accept: application/json
 X-Test-User-Id: {{TestUserId}}
 
+### Check item
+POST {{Trip.API_HostAddress}}/items/{{ItemId}}/check-item
+Accept: application/json
+X-Test-User-Id: {{TestUserId}}
+
 ### Patch item
 PATCH {{Trip.API_HostAddress}}/items/{{ItemId}}
 Accept: application/json

--- a/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs
+++ b/tests/Trip.API.IntegrationTests/Items/CheckItemEndpointTests.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using System.Net.Http.Json;
+using Trip.API.IntegrationTests.Infrastructure;
+
+namespace Trip.API.IntegrationTests.Items;
+
+public sealed class CheckItemEndpointTests
+{
+    [Fact]
+    public async Task CheckItem_ReturnsUpdatedItem_WhenOwnedByCurrentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Lisbon");
+        var item = await CreateItemAsync(client, trip.Id, "Passport");
+
+        var response = await client.PostAsync($"/items/{item.Id}/check-item", null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var checkedItem = await response.Content.ReadFromJsonAsync<ItemResponseContract>();
+        Assert.NotNull(checkedItem);
+        Assert.Equal(item.Id, checkedItem!.Id);
+        Assert.Equal("Passport", checkedItem.Name);
+        Assert.Equal(1, checkedItem.CheckCount);
+    }
+
+    [Fact]
+    public async Task CheckItem_ReturnsUnauthorized_WhenUserHeaderIsMissing()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+
+        var response = await client.PostAsync($"/items/{Guid.NewGuid()}/check-item", null);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckItem_ReturnsForbidden_WhenItemBelongsToDifferentUser()
+    {
+        await using var factory = new TripApiFactory();
+        using var ownerClient = factory.CreateApiClient();
+        ownerClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(ownerClient, "Berlin");
+        var item = await CreateItemAsync(ownerClient, trip.Id, "Passport");
+
+        using var otherClient = factory.CreateApiClient();
+        otherClient.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await otherClient.PostAsync($"/items/{item.Id}/check-item", null);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckItem_ReturnsNotFound_WhenItemDoesNotExist()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+
+        var response = await client.PostAsync($"/items/{Guid.NewGuid()}/check-item", null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckItem_CanBeCalledMultipleTimes_AndRetrievalsShowLatestCount()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Porto");
+        var item = await CreateItemAsync(client, trip.Id, "Passport");
+
+        await client.PostAsync($"/items/{item.Id}/check-item", null);
+        var secondCheckResponse = await client.PostAsync($"/items/{item.Id}/check-item", null);
+        var getItemResponse = await client.GetAsync($"/items/{item.Id}");
+        var listItemsResponse = await client.GetAsync($"/trips/{trip.Id}/items");
+
+        Assert.Equal(HttpStatusCode.OK, secondCheckResponse.StatusCode);
+        var checkedItem = await secondCheckResponse.Content.ReadFromJsonAsync<ItemResponseContract>();
+        Assert.NotNull(checkedItem);
+        Assert.Equal(2, checkedItem!.CheckCount);
+
+        var retrievedItem = await getItemResponse.Content.ReadFromJsonAsync<ItemResponseContract>();
+        Assert.NotNull(retrievedItem);
+        Assert.Equal(2, retrievedItem!.CheckCount);
+
+        var listedItems = await listItemsResponse.Content.ReadFromJsonAsync<ItemResponseContract[]>();
+        Assert.NotNull(listedItems);
+        Assert.Single(listedItems!);
+        Assert.Equal(2, listedItems[0].CheckCount);
+    }
+
+    [Fact]
+    public async Task CheckItem_PreservesItemFields_BesidesCheckCount()
+    {
+        await using var factory = new TripApiFactory();
+        using var client = factory.CreateApiClient();
+        client.DefaultRequestHeaders.Add(TestUserContextHeaderNames.UserId, Guid.NewGuid().ToString());
+        var trip = await CreateTripAsync(client, "Rome");
+        var item = await CreateItemAsync(client, trip.Id, "Passport");
+
+        var response = await client.PostAsync($"/items/{item.Id}/check-item", null);
+
+        var checkedItem = await response.Content.ReadFromJsonAsync<ItemResponseContract>();
+        Assert.NotNull(checkedItem);
+        Assert.Equal(item.Id, checkedItem!.Id);
+        Assert.Equal(item.TripId, checkedItem.TripId);
+        Assert.Equal(item.BaggageId, checkedItem.BaggageId);
+        Assert.Equal(item.Name, checkedItem.Name);
+        Assert.Equal(item.DefaultItemId, checkedItem.DefaultItemId);
+    }
+
+    private static async Task<TripResponseContract> CreateTripAsync(HttpClient client, string destination)
+    {
+        var response = await client.PostAsJsonAsync("/trips", new { destination });
+        return (await response.Content.ReadFromJsonAsync<TripResponseContract>())!;
+    }
+
+    private static async Task<ItemResponseContract> CreateItemAsync(HttpClient client, Guid tripId, string name)
+    {
+        var response = await client.PostAsJsonAsync($"/trips/{tripId}/items", new { name });
+        return (await response.Content.ReadFromJsonAsync<ItemResponseContract>())!;
+    }
+
+    private sealed record TripResponseContract(Guid Id, string Destination, DateOnly? StartDate, DateOnly? EndDate);
+    private sealed record ItemResponseContract(Guid Id, Guid TripId, Guid BaggageId, string Name, int CheckCount, Guid? DefaultItemId);
+}

--- a/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/CheckItemHandlerTests.cs
@@ -1,35 +1,35 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Trip.API.Application.Abstractions;
 using Trip.API.Application.Exceptions;
-using Trip.API.Application.Items.GetItem;
-using Trip.API.Domain.Entities;
+using Trip.API.Application.Items.CheckItem;
 using Trip.API.Domain.ValueObjects;
 using Trip.API.UnitTests.Testing;
 using TripEntity = Trip.API.Domain.Entities.Trip;
 
 namespace Trip.API.UnitTests.Application.Items;
 
-public sealed class GetItemHandlerTests
+public sealed class CheckItemHandlerTests
 {
     [Fact]
-    public async Task HandleAsync_ReturnsItem_WhenOwnedByCurrentUser()
+    public async Task HandleAsync_ReturnsUpdatedItem_WhenOwnedByCurrentUser()
     {
         var trip = TripFixtures.CreateTrip();
         var item = trip.AddItemToDefaultBaggage("Passport");
-        var handler = new GetItemHandler(new InMemoryTripRepository(trip), NullLogger<GetItemHandler>.Instance);
+        var handler = new CheckItemHandler(new InMemoryTripRepository(trip), NullLogger<CheckItemHandler>.Instance);
 
-        var result = await handler.HandleAsync(new GetItemQuery(trip.OwnerId, item.Id), CancellationToken.None);
+        var result = await handler.HandleAsync(new CheckItemCommand(trip.OwnerId, item.Id), CancellationToken.None);
 
         Assert.Equal(item.Id.Value, result.Item.Id);
+        Assert.Equal(1, result.Item.CheckCount);
     }
 
     [Fact]
     public async Task HandleAsync_ThrowsNotFound_WhenItemDoesNotExist()
     {
-        var handler = new GetItemHandler(new InMemoryTripRepository(), NullLogger<GetItemHandler>.Instance);
+        var handler = new CheckItemHandler(new InMemoryTripRepository(), NullLogger<CheckItemHandler>.Instance);
 
         await Assert.ThrowsAsync<NotFoundException>(() => handler.HandleAsync(
-            new GetItemQuery(TripFixtures.CreateUserId(), ItemId.CreateUnique()),
+            new CheckItemCommand(TripFixtures.CreateUserId(), ItemId.CreateUnique()),
             CancellationToken.None));
     }
 
@@ -38,11 +38,24 @@ public sealed class GetItemHandlerTests
     {
         var trip = TripFixtures.CreateTrip();
         var item = trip.AddItemToDefaultBaggage("Passport");
-        var handler = new GetItemHandler(new InMemoryTripRepository(trip), NullLogger<GetItemHandler>.Instance);
+        var handler = new CheckItemHandler(new InMemoryTripRepository(trip), NullLogger<CheckItemHandler>.Instance);
 
         await Assert.ThrowsAsync<ForbiddenException>(() => handler.HandleAsync(
-            new GetItemQuery(TripFixtures.CreateUserId(), item.Id),
+            new CheckItemCommand(TripFixtures.CreateUserId(), item.Id),
             CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task HandleAsync_CanIncrementSameItemMultipleTimes()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+        var handler = new CheckItemHandler(new InMemoryTripRepository(trip), NullLogger<CheckItemHandler>.Instance);
+
+        await handler.HandleAsync(new CheckItemCommand(trip.OwnerId, item.Id), CancellationToken.None);
+        var result = await handler.HandleAsync(new CheckItemCommand(trip.OwnerId, item.Id), CancellationToken.None);
+
+        Assert.Equal(2, result.Item.CheckCount);
     }
 
     private sealed class InMemoryTripRepository : ITripRepository
@@ -55,7 +68,8 @@ public sealed class GetItemHandlerTests
         }
 
         public Task AddAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
-        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken) => throw new NotSupportedException();
+
+        public Task UpdateAsync(TripEntity trip, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<TripEntity?> GetByIdAsync(TripId tripId, CancellationToken cancellationToken)
             => Task.FromResult(_trips.SingleOrDefault(trip => trip.Id == tripId));

--- a/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/CreateItemInTripHandlerTests.cs
@@ -86,5 +86,8 @@ public sealed class CreateItemInTripHandlerTests
 
         public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
             => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+
+        public Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
     }
 }

--- a/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/ListItemsByTripHandlerTests.cs
@@ -66,5 +66,8 @@ public sealed class ListItemsByTripHandlerTests
 
         public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
             => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+
+        public Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
     }
 }

--- a/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Items/PatchItemHandlerTests.cs
@@ -91,5 +91,8 @@ public sealed class PatchItemHandlerTests
 
         public Task<TripEntity?> GetTripByItemIdAsync(ItemId itemId, CancellationToken cancellationToken)
             => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+
+        public Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+            => Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
     }
 }

--- a/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/CreateTripHandlerTests.cs
@@ -73,6 +73,11 @@ public sealed class CreateTripHandlerTests
             return Task.FromResult(Trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
         }
 
+        public Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(Trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+        }
+
         public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<TripEntity>>(Trips.Where(trip => trip.OwnerId == ownerId).ToArray());

--- a/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/GetTripByIdHandlerTests.cs
@@ -74,6 +74,11 @@ public sealed class GetTripByIdHandlerTests
             return Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
         }
 
+        public Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+        }
+
         public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());

--- a/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs
+++ b/tests/Trip.API.UnitTests/Application/Trips/GetTripsHandlerTests.cs
@@ -59,6 +59,11 @@ public sealed class GetTripsHandlerTests
             return Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
         }
 
+        public Task<TripEntity?> GetTripByItemIdForUpdateAsync(ItemId itemId, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_trips.SingleOrDefault(trip => trip.FindItem(itemId) is not null));
+        }
+
         public Task<IReadOnlyList<TripEntity>> GetByOwnerIdAsync(UserId ownerId, CancellationToken cancellationToken)
         {
             return Task.FromResult<IReadOnlyList<TripEntity>>(_trips.Where(trip => trip.OwnerId == ownerId).ToArray());

--- a/tests/Trip.API.UnitTests/Domain/ItemTests.cs
+++ b/tests/Trip.API.UnitTests/Domain/ItemTests.cs
@@ -65,4 +65,47 @@ public sealed class ItemTests
 
         Assert.Equal(2, item.CheckCount);
     }
+
+    [Fact]
+    public void Check_IncrementsCheckCountByOne()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+
+        item.Check();
+
+        Assert.Equal(1, item.CheckCount);
+    }
+
+    [Fact]
+    public void Check_CanBeCalledMultipleTimes()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport");
+
+        item.Check();
+        item.Check();
+
+        Assert.Equal(2, item.CheckCount);
+    }
+
+    [Fact]
+    public void Check_DoesNotChangeIdentityOrMetadata()
+    {
+        var trip = TripFixtures.CreateTrip();
+        var item = trip.AddItemToDefaultBaggage("Passport", Guid.NewGuid());
+        var originalId = item.Id;
+        var originalTripId = item.TripId;
+        var originalBaggageId = item.BaggageId;
+        var originalName = item.Name;
+        var originalDefaultItemId = item.DefaultItemId;
+
+        item.Check();
+
+        Assert.Equal(originalId, item.Id);
+        Assert.Equal(originalTripId, item.TripId);
+        Assert.Equal(originalBaggageId, item.BaggageId);
+        Assert.Equal(originalName, item.Name);
+        Assert.Equal(originalDefaultItemId, item.DefaultItemId);
+    }
 }


### PR DESCRIPTION
  ## Summary

  Implements the item check flow for trip items.

  This adds support for `POST /items/{itemId}/check-item`, where checking an item increments its `checkCount` instead of
  toggling a boolean state. The change preserves item identity and ownership rules, and keeps the updated count visible
  in existing item retrieval endpoints.

  ## Changes

  - added the `checkItem` application flow and API endpoint
  - wired endpoint naming, routing, logging, and DI registration for item checking
  - extended repository access to load an owned item for update and persist the incremented `checkCount`
  - added unit tests for:
    - single check increment
    - repeated checks
    - forbidden and missing-item failures
    - item field integrity during checks
  - added integration tests for:
    - successful item check
    - repeated checks
    - unauthorized, forbidden, and not-found responses
    - updated `checkCount` visibility in get/list item endpoints
  - updated HTTP examples for manual verification
  - marked the feature tasks complete in `specs/003-item-check-counter/tasks.md`

  ## Verification

  - `dotnet build --no-incremental`
  - `dotnet test --no-build`
  - `dotnet format --verify-no-changes`

  ## Spec / Task Reference

  - Feature branch: `003-item-check-counter`
  - Task/spec scope: item check counter